### PR TITLE
TA-489 : display tasks comments in chronological order

### DIFF
--- a/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -232,6 +233,7 @@ public final class TaskUtil {
 
     int limitComment = loadAllComment ? -1 : 2;
     List<Comment> cmts = Arrays.asList(ListUtil.load(listComments, 0, limitComment));
+    Collections.reverse(cmts);
     List<CommentModel> comments = new ArrayList<CommentModel>(cmts.size());
     for(Comment c : cmts) {
       org.exoplatform.task.model.User u = userService.loadUser(c.getAuthor());


### PR DESCRIPTION
The fix simply reverses the collection of comments.
The other option is to change the SQL query to retrieve results directly in the right order. It allows to avoid the reverse, but it requires to use offset in the SQL query, so I don't think it is much better.