### PR TITLE
TA-498 : keep lines returns on tasks comments

### DIFF
--- a/services/src/main/java/org/exoplatform/task/util/CommentUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/CommentUtil.java
@@ -19,8 +19,6 @@
 
 package org.exoplatform.task.util;
 
-import java.util.StringTokenizer;
-
 import org.exoplatform.commons.utils.HTMLEntityEncoder;
 import org.exoplatform.task.model.User;
 import org.exoplatform.task.service.UserService;
@@ -30,19 +28,21 @@ import org.exoplatform.task.service.UserService;
  */
 public final class CommentUtil {
 
+  // regex allowing to return tokens and delimiters
+  public static final String WITH_DELIMITER = "((?<=[%1$s])|(?=[%1$s]))";
+
   private CommentUtil() {
   }
 
-  public static String formatMention(String text, UserService userService) {
+  public static String formatComment(String text, UserService userService) {
     if(text == null || text.isEmpty()) {
       return text;
     }
     HTMLEntityEncoder encoder = HTMLEntityEncoder.getInstance();
     StringBuilder sb = new StringBuilder();
 
-    StringTokenizer tokenizer = new StringTokenizer(text);
-    while(tokenizer.hasMoreElements()) {
-      String next = (String)tokenizer.nextElement();
+    String[] textParts = text.split(String.format(WITH_DELIMITER, "\\s\\t\\n\\r\\f"));
+    for (String next : textParts) {
       if(next.length() == 0) {
         continue;
       } else if(next.charAt(0) == '@') {
@@ -53,11 +53,12 @@ public final class CommentUtil {
         } else {
           next = encoder.encodeHTML(next);
         }
+      } else if(next.equals("\n") || next.equals("\n\r")) {
+        next = "<br>";
       } else {
         next = encoder.encodeHTML(next);
       }
       sb.append(next);
-      sb.append(' ');
     }
 
     return sb.toString();

--- a/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
@@ -233,13 +233,13 @@ public final class TaskUtil {
     List<CommentModel> comments = new ArrayList<CommentModel>(cmts.size());
     for(Comment c : cmts) {
       org.exoplatform.task.model.User u = userService.loadUser(c.getAuthor());
-      comments.add(new CommentModel(c, u, CommentUtil.formatMention(c.getComment(), userService)));
+      comments.add(new CommentModel(c, u, CommentUtil.formatComment(c.getComment(), userService)));
     }
     taskModel.setComments(comments);
 
     org.exoplatform.task.model.User currentUser = userService.loadUser(username);
     taskModel.setCurrentUser(currentUser);
-    
+
     EntityEncoder encoder = HTMLEntityEncoder.getInstance();
     String breadcumbs = "<li class=\"muted\" >" + bundle.getString("label.noProject") + "</li>";
     if (task.getStatus() != null) {

--- a/services/src/test/java/org/exoplatform/task/util/CommentUtilTest.java
+++ b/services/src/test/java/org/exoplatform/task/util/CommentUtilTest.java
@@ -1,0 +1,56 @@
+package org.exoplatform.task.util;
+
+import org.exoplatform.task.model.User;
+import org.exoplatform.task.service.UserService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class CommentUtilTest {
+
+  @Mock
+  UserService userService;
+
+  private String text;
+  private String expectedText;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  public CommentUtilTest(String text, String expectedText) {
+    this.text = text;
+    this.expectedText = expectedText;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<String[]> data() {
+    return Arrays.asList(new String[][]{
+            {"Comment for @thomas", "Comment for <a href=\"http://exoplatform.com/thomas\">Thomas Delhom&eacute;nie</a>"},
+            {"Comment with\nmultilines", "Comment with<br>multilines"},
+            {"Comment for @thomas\nand\nmultilines.", "Comment for <a href=\"http://exoplatform.com/thomas\">Thomas Delhom&eacute;nie</a><br>and<br>multilines."},
+            {"Comment with HTML tags <img>, <a> and <br>", "Comment with HTML tags &lt;img&gt;, &lt;a&gt; and &lt;br&gt;"}
+    });
+  }
+
+  @Test
+  public void testFormatMention() throws Exception {
+    Mockito.when(userService.loadUser("thomas"))
+            .thenReturn(new User("thomas", "thomas.delhomenie@exoplatform.com", "Thomas", "Delhoménie", "Thomas Delhoménie", "", "http://exoplatform.com/thomas"));
+
+    Assert.assertEquals(expectedText, CommentUtil.formatComment(text, userService));
+  }
+}

--- a/task-management/src/main/java/org/exoplatform/task/management/controller/TaskController.java
+++ b/task-management/src/main/java/org/exoplatform/task/management/controller/TaskController.java
@@ -437,8 +437,7 @@ public class TaskController extends AbstractController {
     }
     Comment cmt = taskService.addComment(taskId, currentUser, comment); //Can throw TaskNotFoundException
 
-    //TODO:
-    CommentModel model = new CommentModel(cmt, userService.loadUser(cmt.getAuthor()), CommentUtil.formatMention(cmt.getComment(), userService));
+    CommentModel model = new CommentModel(cmt, userService.loadUser(cmt.getAuthor()), CommentUtil.formatComment(cmt.getComment(), userService));
 
     DateFormat df = new SimpleDateFormat("MMM dd, yyyy HH:mm");
     df.setTimeZone(userService.getUserTimezone(currentUser));
@@ -475,7 +474,7 @@ public class TaskController extends AbstractController {
       List<CommentModel> listComments = new ArrayList<CommentModel>(cmts.length);
       for(Comment cmt : cmts) {
         org.exoplatform.task.model.User u = userService.loadUser(cmt.getAuthor());
-        listComments.add(new CommentModel(cmt, u, CommentUtil.formatMention(cmt.getComment(), userService)));
+        listComments.add(new CommentModel(cmt, u, CommentUtil.formatComment(cmt.getComment(), userService)));
       }
 
       org.exoplatform.task.model.User currentUser = userService.loadUser(securityContext.getRemoteUser());


### PR DESCRIPTION
This PR converts lines returns in <br> tags for rendering, instead of converting them in spaces.
