### PR TITLE
TA-484: Put the focus in the field when editing rich editor fields

### DIFF
--- a/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/x-editable-ckeditor.js
+++ b/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/x-editable-ckeditor.js
@@ -24,6 +24,7 @@ define('x_editable_ckeditor', ['SHARED/jquery', 'SHARED/edit_inline_js', 'SHARED
                 var _this = this;
                 CKEDITOR.on('instanceReady', function(e) {
                     _this.$input.parent().find('> .cke').removeClass('cke');
+                    e.editor.focus();
                 });
             },
             value2html: function(value, element) {


### PR DESCRIPTION
[![Review](http://beta.codenvy.com/factory/resources/codenvy-review.svg)](http://beta.codenvy.com/f?id=ek3pwqml2u6czzt6)

This PR set the focus on a rich editor field when the field is ready to use.