### PR TITLE
SWF-3869: Update PLF components versions to 5.0.x-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>addons-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>7-RC01</version>
+    <version>8-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.addons.task</groupId>
   <artifactId>task-management-parent</artifactId>
@@ -47,8 +47,8 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <org.exoplatform.platform.version>4.5.x-SNAPSHOT</org.exoplatform.platform.version>
-    <juzu.version>1.1.0</juzu.version>
+    <org.exoplatform.platform.version>5.0.x-SNAPSHOT</org.exoplatform.platform.version>
+    <org.juzu.version>1.1.3</org.juzu.version>
     <org.antlr.version>3.4</org.antlr.version>
     <org.webjars.jquery.version>1.11.2</org.webjars.jquery.version>
     <org.webjars.jquery-ui.version>1.11.4</org.webjars.jquery-ui.version>
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>org.juzu</groupId>
         <artifactId>juzu-parent</artifactId>
-        <version>${juzu.version}</version>
+        <version>${org.juzu.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/task-management/pom.xml
+++ b/task-management/pom.xml
@@ -114,7 +114,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portal</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
* maven dependencies updated to depends on
   * PLF versions 5.0.x-SNAPSHOT
   * groupId org.exoplatform.gatein.* instead of org.gatein for
gatein-wci, gatein-pc and gatein-portal