### PR TITLE
Add project-repositories Maven profile to configure eXo Maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,4 +150,32 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <profiles>
+    <profile>
+      <id>project-repositories</id>
+      <activation>
+        <property>
+          <name>!skip-project-repositories</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>repository.exoplatform.org</id>
+          <url>https://repository.exoplatform.org/public</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>repository.exoplatform.org</id>
+          <url>https://repository.exoplatform.org/public</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
  * this profile configures the Snapshots Repositories for eXo dependencies and plugins
  * this profile is activated by default, add -Dskip-project-repositories to disable it

Without this Maven profile activated the Maven build should failed because of non-resolvable parent POM:
```
$ docker run --rm -it -v $(pwd):/srv/ciagent/workspace exoplatform/ci:jdk8-maven33 clean install -Dskip-project-repositories

[ERROR]   The project org.exoplatform.addons.task:task-management-parent:1.3.x-SNAPSHOT (/srv/ciagent/workspace/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.exoplatform.addons.task:task-management-parent:1.3.x-SNAPSHOT: Could not find artifact org.exoplatform.addons:addons-parent-pom:pom:8-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 24, column 11 -> [Help 2]
```

**With this new profile activated** (and no specific Maven settings configuration related to eXo), this build should be ok:
```
$ docker run --rm -it -v $(pwd):/srv/ciagent/workspace exoplatform/ci:jdk8-maven33 clean install 
```
