### PR TITLE
TA-589 : emulate click outside field on blur event to save fields when leaving it with tab

### DIFF
--- a/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/editinline.js
+++ b/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/editinline.js
@@ -764,6 +764,9 @@ define('ta_edit_inline',
                 $this.on('shown', function (e, editable) {
                     if (editable != undefined) {
                         $this.parent().removeClass('inactive').addClass('active');
+                        $this.data('editable').input.$input.on('blur', function() {
+                            $(document.body).trigger('click');
+                        });
                     }
                 }).on('hidden', function (e, editable) {
                     if (editable != undefined) {

--- a/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/x-editable-ckeditor.js
+++ b/task-management/src/main/java/org/exoplatform/task/management/assets/javascripts/x-editable-ckeditor.js
@@ -27,7 +27,12 @@ define('x_editable_ckeditor', ['SHARED/jquery', 'SHARED/edit_inline_js', 'SHARED
                     ['Bold','Italic','Underline'],
                     ['TextColor'],
                     ['NumberedList','BulletedList']
-                  ]
+                  ],
+                  on: {
+                      blur: function () {
+                          $(document.body).trigger('click');
+                      }
+                  }
                 });
                 editor.editor.setData(this.options.scope.innerHTML);
             },


### PR DESCRIPTION
Editable fields (managed by bootstrap-editable lib) do not react to blur event, only on click event. This PR uses the blur event on inputs and ckeditor and emulate a click on the page to trigger the same behavior than a click outside the field.