### PR TITLE
TA-596 : use span for the task comments containers to allow comments using p tag to be displayed and initerpreted correctly (p inside p is not allowed)

### DIFF
--- a/task-management/src/main/java/org/exoplatform/task/management/templates/taskComments.gtmpl
+++ b/task-management/src/main/java/org/exoplatform/task/management/templates/taskComments.gtmpl
@@ -44,9 +44,9 @@
                         <%= TaskUtil.getPeriod(comment.getCreatedTime().getTime(), bundle)%>
                      </span>
                 </div>
-                <p class="contentComment">
+                <span class="contentComment">
                     ${comment.formattedComment}
-                </p>
+                </span>
                 <p>
                     <a href="javascript:void(0)" class="replyCommentLink">&{comment.message.Reply}</a>
                 </p>


### PR DESCRIPTION
CKEditor wraps the content of the comments inside p tags. Since the html container for task comments was also a p, it resulted in p inside p, which is not allowed and rendered an incorrect DOM. This PR replaces p by span which allows to contain p.