### PR TITLE
TA-610 : allow to define task without due date in Chat

### DIFF
--- a/integration/src/main/java/org/exoplatform/task/integration/chat/ChatPopupPlugin.java
+++ b/integration/src/main/java/org/exoplatform/task/integration/chat/ChatPopupPlugin.java
@@ -154,6 +154,7 @@ public class ChatPopupPlugin extends BaseUIPlugin {
     String actionName = context.getName();
     String creator = ConversationState.getCurrent().getIdentity().getUserId();
     String taskInput = getParam("text", params);
+    String dueDateInput = getParam("dueDate", params);
 
     Status status = getStatus(params);
         
@@ -162,12 +163,14 @@ public class ChatPopupPlugin extends BaseUIPlugin {
       username = StringUtils.isEmpty(username) ? creator : username;
 
       sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm");
-      Date dueDate = new Date();
-      try {
-        dueDate = sdf.parse(getParam("dueDate", params) + " 23:59");
-      } catch (Exception ex) {
-        log.error(ex.getMessage(), ex);
-      }      
+      Date dueDate = null;
+      if(StringUtils.isNotBlank(dueDateInput)) {
+        try {
+          dueDate = sdf.parse(dueDateInput + " 23:59");
+        } catch (Exception ex) {
+          log.error("Cannot parse due date " + dueDateInput + " : " + ex.getMessage(), ex);
+        }
+      }
 
       JSONArray jTasks = new JSONArray();
       for (String name : username.split(",")) {

--- a/task-management/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/task-management/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -187,6 +187,9 @@
     <depends>
       <module>uiMiniCalendar</module>
     </depends>
+    <depends>
+      <module>bootbox</module>
+    </depends>
 	</module>
 
 

--- a/task-management/src/main/webapp/js/TaskChatPlugin.js
+++ b/task-management/src/main/webapp/js/TaskChatPlugin.js
@@ -50,12 +50,12 @@
     }
 
     // Validate empty
-    if (task === $("#task-add-task").attr("data-value") || task === "" || dueDate === "") {
+    if (task === $("#task-add-task").attr("data-value") || task === "") {
       return;
     }
 
     // Validate datetime
-    if (!uiMiniCalendar.isDate(dueDate)) {
+    if (dueDate && !uiMiniCalendar.isDate(dueDate)) {
       bootbox
         .alertError(
           chatBundleData["exoplatform.chat.date.invalid.message"],
@@ -250,6 +250,14 @@
     },
     "messageBeautifier" : function(objMessage, options) {
       if (options.type === "type-task") {
+        var assignee = options.username;
+        if(!assignee) {
+          assignee = chatBundleData["exoplatform.chat.assign.to.none"];
+        }
+        var dueDate = options.dueDate;
+        if(!dueDate) {
+          dueDate = chatBundleData["exoplatform.chat.due.date.none"];
+        }
         var out = "";
         if (options.url) {
           out += "<b><a href='" + options.url + "' target='_blank'>" + options.task + "</a></b>";
@@ -260,12 +268,12 @@
         out += "  <div>";
         out += "    <i class='uiIconChatAssign uiIconChatLightGray mgR10'></i><span class='muted'>"
           + chatBundleData["exoplatform.chat.assign.to"]
-          + ": </span>" + options.username;
+          + ": </span><b>" + assignee + "</b>";
         out += "  </div>";
         out += "  <div>";
         out += "    <i class='uiIconChatClock uiIconChatLightGray mgR10'></i><span class='muted'>"
           + chatBundleData["exoplatform.chat.due.date"]
-          + ":</span> <b>" + options.dueDate + "</b>";
+          + ": </span><b>" + dueDate + "</b>";
         out += "  </div>";
         out += "</div>";
         return out;


### PR DESCRIPTION
It was not allowed to create task without due date in Chat through the Assign Task popup, whereas it was possible with the ++ syntax.
This fix makes the due date field in the Assign Task popup optional to be consistent.
It also adds i18n labels for unassigned and unplanned tasks.