### PR TITLE
Change the task title css style

### DIFF
--- a/task-management/src/main/java/org/exoplatform/task/management/assets/less/style.less
+++ b/task-management/src/main/java/org/exoplatform/task/management/assets/less/style.less
@@ -1502,6 +1502,11 @@ li[data-hiddenlabel="false"] {
 .table-project .column-checkbox .status-task.block-hide {
     margin-left: 8px;
 }
+
+.table-project .column-time {
+    width: 27px;
+}
+
 .breadcrumb .removeProject {
     display: inline;
     float: none;

--- a/task-management/src/main/java/org/exoplatform/task/management/templates/taskListView.gtmpl
+++ b/task-management/src/main/java/org/exoplatform/task/management/templates/taskListView.gtmpl
@@ -143,7 +143,7 @@
                             <% }%>
                             <% if (!TaskUtil.hasViewOnlyPermission(task)) {%>
                             <a class="actionIcon inline-block-hide"
-                               data-placement="left"
+                               data-placement="top"
                                data-original-title="<% if (task.completed) {%> &{message.markAsUnCompleted} <%} else {%> &{message.markAsCompleted} <%}%>"
                                rel="tooltip"
                                data-taskcompleted="${task.completed}"
@@ -261,7 +261,7 @@
                 <span class="text-time inline-block-show">{{taskDueDate}}</span>
                 <span class="labels">
                 </span>
-                <a class="actionIcon inline-block-hide" data-placement="left" data-original-title="&{message.markAsCompleted}" rel="tooltip" data-taskcompleted="{{taskCompleted}}" href="javascript:void(0)">
+                <a class="actionIcon inline-block-hide" data-placement="top" data-original-title="&{message.markAsCompleted}" rel="tooltip" data-taskcompleted="{{taskCompleted}}" href="javascript:void(0)">
                     <i class="uiIconValidate uiIconLightGray"></i>
                 </a>
             </div>


### PR DESCRIPTION
Change the task title's css style to take more display space.
Show the tooltip "Mark as completed" above the icon instead of on the left to not hide the task title.