### PR TITLE
PLF-6637 : display only allowed groups for user (#150)

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
   <name>eXo Add-on:: Task Management - Integration</name>
   <properties>
-    <exo.test.coverage.ratio>0.12</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.14</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/integration/src/main/java/org/exoplatform/task/integration/ProjectGroupVisibilityPlugin.java
+++ b/integration/src/main/java/org/exoplatform/task/integration/ProjectGroupVisibilityPlugin.java
@@ -1,0 +1,35 @@
+package org.exoplatform.task.integration;
+
+import org.exoplatform.portal.config.GroupVisibilityPlugin;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.MembershipEntry;
+
+import java.util.Collection;
+
+/**
+ * The user can see a group only when:
+ * * the given user is the super user
+ * * the given user is a platform administrator
+ * * the given user is a manager of the group
+ */
+public class ProjectGroupVisibilityPlugin extends GroupVisibilityPlugin {
+
+  private UserACL userACL;
+
+  public ProjectGroupVisibilityPlugin(UserACL userACL) {
+    this.userACL = userACL;
+  }
+
+  public boolean hasPermission(Identity userIdentity, Group group) {
+    Collection<MembershipEntry> userMemberships = userIdentity.getMemberships();
+    return userACL.getSuperUser().equals(userIdentity.getUserId())
+        || userMemberships.stream()
+                          .anyMatch(userMembership -> userMembership.getGroup().equals(userACL.getAdminGroups())
+                              || ((userMembership.getGroup().equals(group.getId())
+                                  || userMembership.getGroup().startsWith(group.getId() + "/"))
+                                  && (userMembership.getMembershipType().equals("*")
+                                      || userMembership.getMembershipType().equals("manager"))));
+  }
+}

--- a/integration/src/test/java/org/exoplatform/task/integration/ProjectGroupVisibilityPluginTest.java
+++ b/integration/src/test/java/org/exoplatform/task/integration/ProjectGroupVisibilityPluginTest.java
@@ -1,0 +1,118 @@
+package org.exoplatform.task.integration;
+
+import org.exoplatform.portal.config.GroupVisibilityPlugin;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.impl.GroupImpl;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.MembershipEntry;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProjectGroupVisibilityPluginTest {
+    @Test
+    public void shouldHasPermissionWhenUserIsSuperUser() {
+        // Given
+        UserACL userACL = mock(UserACL.class);
+        when(userACL.getSuperUser()).thenReturn("john");
+        GroupVisibilityPlugin plugin = new ProjectGroupVisibilityPlugin(userACL);
+
+        Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/users", "manager")));
+        Group groupPlatform = new GroupImpl();
+        groupPlatform.setId("/platform");
+        Group groupPlatformUsers = new GroupImpl();
+        groupPlatformUsers.setId("/platform/users");
+
+        // When
+        boolean hasPermissionOnPlatform = plugin.hasPermission(userIdentity, groupPlatform);
+        boolean hasPermissionOnPlatformUsers = plugin.hasPermission(userIdentity, groupPlatformUsers);
+
+        // Then
+        assertTrue(hasPermissionOnPlatform);
+        assertTrue(hasPermissionOnPlatformUsers);
+    }
+
+    @Test
+    public void shouldHasPermissionWhenUserIsPlatformAdministrator() {
+        // Given
+        UserACL userACL = mock(UserACL.class);
+        when(userACL.getSuperUser()).thenReturn("root");
+        when(userACL.getAdminGroups()).thenReturn("/platform/administrators");
+        GroupVisibilityPlugin plugin = new ProjectGroupVisibilityPlugin(userACL);
+
+        Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/administrators", "manager")));
+        Group groupPlatform = new GroupImpl();
+        groupPlatform.setId("/platform");
+        Group groupPlatformUsers = new GroupImpl();
+        groupPlatformUsers.setId("/platform/users");
+
+        // When
+        boolean hasPermissionOnPlatform = plugin.hasPermission(userIdentity, groupPlatform);
+        boolean hasPermissionOnPlatformUsers = plugin.hasPermission(userIdentity, groupPlatformUsers);
+
+        // Then
+        assertTrue(hasPermissionOnPlatform);
+        assertTrue(hasPermissionOnPlatformUsers);
+    }
+
+    @Test
+    public void shouldHasPermissionWhenUserIsInGivenGroup() {
+        // Given
+        UserACL userACL = mock(UserACL.class);
+        when(userACL.getSuperUser()).thenReturn("root");
+        when(userACL.getAdminGroups()).thenReturn("/platform/administrators");
+        GroupVisibilityPlugin plugin = new ProjectGroupVisibilityPlugin(userACL);
+
+        Identity userIdentity = new Identity("john",
+                Arrays.asList(new MembershipEntry("/platform/developers", "manager"),
+                        new MembershipEntry("/platform/testers", "member"),
+                        new MembershipEntry("/spaces/marketing", "member"),
+                        new MembershipEntry("/spaces/sales", "manager"),
+                        new MembershipEntry("/organization/rh", "*")));
+        Group groupPlatform = new GroupImpl();
+        groupPlatform.setId("/platform");
+        Group groupPlatformDevelopers = new GroupImpl();
+        groupPlatformDevelopers.setId("/platform/developers");
+        Group groupPlatformTesters = new GroupImpl();
+        groupPlatformTesters.setId("/platform/testers");
+        Group groupSpaces = new GroupImpl();
+        groupSpaces.setId("/spaces");
+        Group groupSpacesMarketing = new GroupImpl();
+        groupSpacesMarketing.setId("/spaces/marketing");
+        Group groupSpacesSales = new GroupImpl();
+        groupSpacesSales.setId("/spaces/sales");
+        Group groupSpacesEngineering = new GroupImpl();
+        groupSpacesEngineering.setId("/spaces/engineering");
+        Group groupOrganization = new GroupImpl();
+        groupOrganization.setId("/organization");
+        Group groupOrganizationRh = new GroupImpl();
+        groupOrganizationRh.setId("/organization/rh");
+
+        // When
+        boolean hasPermissionOnPlatform = plugin.hasPermission(userIdentity, groupPlatform);
+        boolean hasPermissionOnPlatformDevelopers = plugin.hasPermission(userIdentity, groupPlatformDevelopers);
+        boolean hasPermissionOnPlatformTesters = plugin.hasPermission(userIdentity, groupPlatformTesters);
+        boolean hasPermissionOnSpaces = plugin.hasPermission(userIdentity, groupSpaces);
+        boolean hasPermissionOnSpacesMarketing = plugin.hasPermission(userIdentity, groupSpacesMarketing);
+        boolean hasPermissionOnSpacesSales = plugin.hasPermission(userIdentity, groupSpacesSales);
+        boolean hasPermissionOnSpacesEngineering = plugin.hasPermission(userIdentity, groupSpacesEngineering);
+        boolean hasPermissionOnOrganization = plugin.hasPermission(userIdentity, groupOrganization);
+        boolean hasPermissionOnOrganizationRh = plugin.hasPermission(userIdentity, groupOrganizationRh);
+
+        // Then
+        assertTrue(hasPermissionOnPlatform);
+        assertTrue(hasPermissionOnPlatformDevelopers);
+        assertFalse(hasPermissionOnPlatformTesters);
+        assertTrue(hasPermissionOnSpaces);
+        assertFalse(hasPermissionOnSpacesMarketing);
+        assertTrue(hasPermissionOnSpacesSales);
+        assertFalse(hasPermissionOnSpacesEngineering);
+        assertTrue(hasPermissionOnOrganization);
+        assertTrue(hasPermissionOnOrganizationRh);
+    }
+}

--- a/task-management/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/task-management/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -86,4 +86,13 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.portal.config.UserACL</target-component>
+    <component-plugin>
+      <name>tasks_projects_permissions</name>
+      <set-method>addGroupVisibilityPlugin</set-method>
+      <type>org.exoplatform.task.integration.ProjectGroupVisibilityPlugin</type>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>


### PR DESCRIPTION
In permimssions selector, all the groups are displayed. This discloses information, like hidden spaces, technical groups, ...

This fix adds a filter on UserACL to display only the groups authorized for the given user.