### PR TITLE
TASK-38016: Restrict mentionning and assigning to projects participants

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -9,8 +9,11 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.profile.ProfileFilter;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.ProjectQuery;
 import org.exoplatform.task.dto.ProjectDto;
@@ -56,13 +59,16 @@ public class ProjectRestService implements ResourceContainer {
 
   private CommentService commentService;
 
+  private IdentityManager  identityManager;
+
   public ProjectRestService(TaskService taskService,
                             CommentService commentService,
                             ProjectService projectService,
                             StatusService statusService,
                             UserService userService,
                             SpaceService spaceService,
-                            LabelService labelService) {
+                            LabelService labelService,
+                            IdentityManager identityManager) {
     this.taskService = taskService;
     this.commentService = commentService;
     this.projectService = projectService;
@@ -70,6 +76,7 @@ public class ProjectRestService implements ResourceContainer {
     this.userService = userService;
     this.spaceService = spaceService;
     this.labelService = labelService;
+    this.identityManager = identityManager;
   }
 
   private enum TaskType {
@@ -585,33 +592,46 @@ public class ProjectRestService implements ResourceContainer {
   }
 
   @GET
-  @Path("projectParticipants/{idProject}")
+  @Path("projectParticipants/{idProject}/{term}")
   @RolesAllowed("users")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Gets participants", httpMethod = "GET", response = Response.class, notes = "This returns participants in project")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Request fulfilled")})
-  public Response getProjectParticipants(@ApiParam(value = "Project id", required = true) @PathParam("idProject") long idProject) throws Exception {
-    Set<String> participants = projectService.getParticipator(idProject);
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Request fulfilled") })
+  public Response getProjectParticipants(@ApiParam(value = "Project id", required = true) @PathParam("idProject") long idProject,
+                                         @ApiParam(value = "User name search information", required = false) @PathParam("term") String term) throws Exception { Set<String> participants = projectService.getParticipator(idProject);
     JSONArray usersJsonArray = new JSONArray();
-    Set<String> members = new HashSet<String>();
-    JSONObject userJson = new JSONObject();
+    Set<String> members = new HashSet<>();
+    Type type = Type.valueOf(Type.MEMBER.name().toUpperCase());
+    ProfileFilter profileFilter = new ProfileFilter();
+    profileFilter.setName(term);
     for (String participant : participants) {
       int index = participant.indexOf(':');
       if (index > -1) {
         String groupId = participant.substring(index + 1);
         Space space = spaceService.getSpaceByGroupId(groupId);
-        if (space != null) members.addAll(Arrays.asList(space.getMembers()));
+        ListAccess<org.exoplatform.social.core.identity.model.Identity> spaceIdentitiesListAccess =
+                                                                                                  identityManager.getSpaceIdentityByProfileFilter(space,
+                                                                                                                                                  profileFilter,
+                                                                                                                                                  type,
+                                                                                                                                                  true);
+        org.exoplatform.social.core.identity.model.Identity[] spaceIdentities = spaceIdentitiesListAccess.load(0, 21);
+        if (spaceIdentities.length > 0) {
+          for (int i = 0; i < spaceIdentities.length; i++) {
+            members.addAll(Arrays.asList(spaceIdentities[i].getRemoteId()));
+          }
+        }
       } else {
         members.add(participant);
       }
-      for (String member : members) {
-        User user = UserUtil.getUser(member);
-        userJson.put("id", "@" + user.getUsername());
-        userJson.put("name", user.getDisplayName());
-        userJson.put("avatar", user.getAvatar());
-        userJson.put("type", "contact");
-        usersJsonArray.put(userJson);
-      }
+    }
+    for (String member : members) {
+      User user = UserUtil.getUser(member);
+      JSONObject json = new JSONObject();
+      json.put("id", "@" + user.getUsername());
+      json.put("name", user.getDisplayName());
+      json.put("avatar", user.getAvatar());
+      json.put("type", "contact");
+      usersJsonArray.put(json);
     }
     return Response.ok(usersJsonArray.toString()).build();
   }

--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -584,5 +584,36 @@ public class ProjectRestService implements ResourceContainer {
     return Response.ok(Response.Status.OK).build();
   }
 
+  @GET
+  @Path("projectParticipants/{idProject}")
+  @RolesAllowed("users")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Gets participants", httpMethod = "GET", response = Response.class, notes = "This returns participants in project")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Request fulfilled")})
+  public Response getProjectParticipants(@ApiParam(value = "Project id", required = true) @PathParam("idProject") long idProject) throws Exception {
+    Set<String> participants = projectService.getParticipator(idProject);
+    JSONArray usersJsonArray = new JSONArray();
+    Set<String> members = new HashSet<String>();
+    JSONObject userJson = new JSONObject();
+    for (String participant : participants) {
+      int index = participant.indexOf(':');
+      if (index > -1) {
+        String groupId = participant.substring(index + 1);
+        Space space = spaceService.getSpaceByGroupId(groupId);
+        if (space != null) members.addAll(Arrays.asList(space.getMembers()));
+      } else {
+        members.add(participant);
+      }
+      for (String member : members) {
+        User user = UserUtil.getUser(member);
+        userJson.put("id", "@" + user.getUsername());
+        userJson.put("name", user.getDisplayName());
+        userJson.put("avatar", user.getAvatar());
+        userJson.put("type", "contact");
+        usersJsonArray.put(userJson);
+      }
+    }
+    return Response.ok(usersJsonArray.toString()).build();
+  }
 
 }

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -9,6 +9,7 @@ import java.util.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.task.rest.model.PaginatedTaskList;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,6 +61,9 @@ public class TestProjectRestService {
 
   @Mock
   LabelService   labelService;
+
+  @Mock
+  IdentityManager identityManager;
 
   @Before
   public void setup() {
@@ -146,7 +150,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity root = new Identity("root");
     ConversationState.setCurrent(new ConversationState(root));
 
@@ -177,7 +182,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     ProjectDto project = new ProjectDto();
@@ -207,7 +213,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     ProjectDto project = new ProjectDto();
@@ -235,7 +242,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     Set<String> manager = new HashSet<String>();
@@ -271,7 +279,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     Identity exo = new Identity("exo");
     ConversationState.setCurrent(new ConversationState(john));
@@ -318,7 +327,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity root = new Identity("root");
     ConversationState.setCurrent(new ConversationState(root));
 
@@ -390,7 +400,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
 
     Identity root = new Identity("root");
     ConversationState.setCurrent(new ConversationState(root));
@@ -428,7 +439,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     Set<String> manager = new HashSet<String>();
@@ -454,7 +466,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     Set<String> manager = new HashSet<String>();
@@ -486,7 +499,8 @@ public class TestProjectRestService {
                                                                    statusService,
                                                                    userService,
                                                                    spaceService,
-                                                                   labelService);
+                                                                   labelService,
+                                                                   identityManager);
     Identity john = new Identity("john");
     ConversationState.setCurrent(new ConversationState(john));
     Set<String> manager = new HashSet<String>();

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -51,6 +51,7 @@
           ref="autoFocusInput3"
           :labels="suggesterLabels"
           :value="taskAssigneeObj"
+          :search-options="searchOptions"
           name="taskAssignee"
           type-of-relations="''"
           height="40"
@@ -69,6 +70,7 @@
           ref="autoFocusInput3"
           :labels="suggesterLabels"
           :value="taskCoworkerObj"
+          :search-options="searchOptions"
           name="taskCoworkers"
           type-of-relations="''"
           height="40"
@@ -120,7 +122,12 @@
           placeholder: this.$t('label.assignee'),
           noDataLabel: this.$t('label.noDataLabel'),
         };
-      }
+      },
+      searchOptions() {
+        return {
+          projectId: this.task.status.project.id
+        };
+      },
     },
     mounted() {
       $(document).on('click', (e) => {

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -125,7 +125,7 @@
       },
       searchOptions() {
         return {
-          projectId: this.task.status.project.id
+          searchUrl: '/portal/rest/projects/projectParticipants/'.concat(this.task.status.project.id).concat('/')
         };
       },
     },


### PR DESCRIPTION
**To** Restrict mentionning and assigning to project participants, **we** should add a rest end point to send list of participants of task to social suggester. **so** we add the method `getProjectParticipants`, we add also in `TaskAssignment.vue` a serachOptions to add projectId to retrieve in suggester the list of participants