### PR TITLE
MAINT-38485 : The fields in the Permissions section doesn't restore their default status when clicking outside or closing the drawer

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
@@ -3,7 +3,8 @@
     ref="addProjectDrawer"
     class="addProjectDrawer"
     body-classes="hide-scroll decrease-z-index-more"
-    right>
+    right
+    @closed="cancel">
     <template slot="title">
       {{ labelDrawer }}
     </template>


### PR DESCRIPTION
**The problem** when clicking outside or closing the drawer the default values of drawer doesn't restore **so the solution** is to add the `closed` action
