### PR TITLE
TASK-38612: when Clicking on Reset, the drawer Sort & Filter is closed

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -275,7 +275,6 @@
         this.getFilterNumber()
         this.$root.$emit('reset-filter-task-group-sort',this.groupBy);
         this.$emit('reset-filter-task');
-        this.$refs.filterTasksDrawer.close();
       },
       resetFields(source) {
         this.query='';


### PR DESCRIPTION
when Clicking on Reset, the drawer "Sort & Filter " shouldn't close, so I remove the close drawer action  