### PR TITLE
Task-38547: weird behavior with the drawer Task Assignee And Coworkers

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -33,8 +33,7 @@
       </div>
       <div 
         v-if="assigneeAndCoworkerArray && assigneeAndCoworkerArray.length"
-        class="taskWorker d-flex justify-space-between align-center my-3"
-        @click="openTaskDrawer()">
+        class="taskWorker d-flex justify-space-between align-center my-3">
         <div
           :class="assigneeAndCoworkerArray && !assigneeAndCoworkerArray.length && task && task.labels && !task.labels.length && 'hideTaskAssignee'"
           class="taskAssignee d-flex flex-nowrap">

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -163,7 +163,6 @@
         {{ $t('spacesList.button.showMore') }}
       </v-btn>
     </div>
-    <tasks-assignee-coworker-drawer/>
   </v-app>
 </template>
 <script>

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -26,6 +26,8 @@
     <task-drawer
       ref="taskDrawer"
       :task="task"/>
+
+    <tasks-assignee-coworker-drawer/>
   </v-app>
 </template>
 <script>

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -31,7 +31,7 @@
           <span class="caption text-sub-title">ID : {{ task.task.id }}</span>
         </div>
       </div>
-      <div class="taskAssigneeAndLabels d-flex justify-space-between align-center mt-3" @click="openTaskDrawer()">
+      <div class="taskAssigneeAndLabels d-flex justify-space-between align-center mt-3">
         <div class="taskAssignee d-flex flex-nowrap">
           <exo-user-avatar
             v-for="user in avatarToDisplay"

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -123,7 +123,6 @@
         {{ $t('spacesList.button.showMore') }}
       </v-btn>
     </v-row>
-    <tasks-assignee-coworker-drawer/>
   </v-app>
 </template>
 <script>


### PR DESCRIPTION
The task drawer and the drawer Task Assignee And Coworkers displayed when clicking on the number displayed on the avatar, 
I remove the event that displays the task drawer.
Olso the drawer Task Assignee And Coworkers is still displayed when selecting the tasks tab or project tab even after close it,
I moved the drawer <tasks-assignee-coworker-drawer/> to the parent components