### PR TITLE
TASKS-38699: Display TASKS tab when opening a task not related to a project by the URL

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -101,6 +101,9 @@
           this.task = data  
           if(this.task.status && this.task.status.project){
               document.dispatchEvent(new CustomEvent('showProjectTasks', {detail: this.task.status.project}));
+            this.tab='tab-2'
+          } else {
+            this.tab='tab-1'
           }
           this.$refs.taskDrawer.open(this.task);
         })


### PR DESCRIPTION
When opening a task not related to a project by the URL, it should displayed under the TASKS tab 