### PR TITLE
Task-39421: In tasks app widget in the snapshot page, when clicking o…

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks/components/TaskDetails.vue
+++ b/task-management/src/main/webapp/vue-app/tasks/components/TaskDetails.vue
@@ -109,7 +109,7 @@
         this.$root.$emit('open-task-drawer', this.task.task);
       },
       navigateTo(pagelink) {
-        location.href=`${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/tasks?projectId=${ pagelink }` ;
+        location.href=`${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/tasks/projectDetail/${ pagelink }` ;
       },
     }
   }


### PR DESCRIPTION
…n a project name , the board view of that project is not displayed (#137)