### PR TITLE
TASK-39581: Restrict mentioning users in task comment to only project participants

### DIFF
--- a/services/src/test/java/org/exoplatform/task/TestUtils.java
+++ b/services/src/test/java/org/exoplatform/task/TestUtils.java
@@ -22,6 +22,8 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.task.domain.Comment;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.domain.Status;
@@ -173,6 +175,32 @@ public class TestUtils {
     user.setEmail("root@gmail.com");
 
     return user;
+  }
+
+  public static User getUserA() {
+    User user = new User();
+    user.setUsername("userA");
+    user.setDisplayName("userA");
+    user.setFirstName("userA");
+    user.setLastName("userA");
+    user.setEmail("userA@gmail.com");
+
+    return user;
+  }
+
+  public static org.exoplatform.social.core.identity.model.Identity getUserAIdentity() {
+    org.exoplatform.social.core.identity.model.Identity userIdentity = new org.exoplatform.social.core.identity.model.Identity(OrganizationIdentityProvider.NAME, "userA");
+
+    userIdentity.setEnable(true);
+    userIdentity.setDeleted(false);
+    userIdentity.setRemoteId("userA");
+
+    Profile userProfile = new Profile(userIdentity);
+    userProfile.setProperty(Profile.FULL_NAME, "userA");
+    userProfile.setProperty(Profile.AVATAR, "/userA.png");
+    userIdentity.setProfile(userProfile);
+
+    return userIdentity;
   }
 
 }

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -9,6 +9,7 @@ import java.util.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.task.rest.model.PaginatedTaskList;
 import org.junit.Before;
@@ -17,7 +18,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.rest.impl.RuntimeDelegateImpl;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
@@ -404,30 +404,29 @@ public class TestProjectRestService {
                                                                    identityManager);
 
     Identity root = new Identity("root");
+    final User userA = TestUtils.getUserA();
+    org.exoplatform.social.core.identity.model.Identity userAIdentity = TestUtils.getUserAIdentity();
+
     ConversationState.setCurrent(new ConversationState(root));
+
+    Set<String> projectParticipator = new HashSet<>();
+    projectParticipator.add(root.getUserId());
+    projectParticipator.add(userA.getUsername());
 
     ProjectDto project1 = new ProjectDto();
     project1.setName("project1");
+    project1.setId(1L);
+    project1.setParticipator(projectParticipator);
 
     when(projectService.getProject(project1.getId())).thenReturn(project1);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME,"userA")).thenReturn(userAIdentity);
 
-    final User user = TestUtils.getUser();
-    ListAccess<User> lists = new ListAccess<User>() {
-      @Override
-      public User[] load(int i, int i1) throws Exception, IllegalArgumentException {
-        return new User[] { user };
-      }
+    //when
+    Response response = projectRestService.getUsersByQueryAndProjectId("userA", 1L);
 
-      @Override
-      public int getSize() throws Exception {
-        return 1;
-      }
-    };
-
-    when(userService.findUserByName("root")).thenReturn(lists);
-
-    Response response = projectRestService.getUsersByQueryAndProjectName("root", "project1");
+    //then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertNotNull(response.getEntity());
   }
 
   @Test
@@ -523,5 +522,4 @@ public class TestProjectRestService {
     Response response1 = projectRestService.changeProjectColor(projectDto.getId(), "red");
     assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
   }
-
 }

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -155,6 +155,7 @@
                       v-model="editorData"
                       :max-length="MESSAGE_MAX_LENGTH"
                       :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)"
+                      :task="task"
                       :reset="reset"
                       class="comment"/>
                     <v-btn

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
@@ -67,7 +67,8 @@
       const thiss = this;
       $('body').suggester('addProvider', 'task:people', function (query, callback) {
         const _this = this;
-        findUsersToMention(thiss.task.status.project.id, query).then((data) => {
+        const projectId = thiss.task.status ? thiss.task.status.project.id : null;
+        findUsersToMention(projectId, query).then((data) => {
           const result = [];
           for (let i = 0; i < data.length; i++) {
             const d = data[i];

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
@@ -28,6 +28,10 @@
         type: String,
         default: ''
       },
+      task: {
+        type: Object,
+        default: null
+      },
       reset: {
         type: Boolean,
         default: false
@@ -60,14 +64,15 @@
     },
     mounted() {
       this.initCKEditor();
+      const thiss = this;
       $('body').suggester('addProvider', 'task:people', function (query, callback) {
         const _this = this;
-        findUsersToMention(query).then((data) => {
+        findUsersToMention(thiss.task.status.project.id, query).then((data) => {
           const result = [];
           for (let i = 0; i < data.length; i++) {
             const d = data[i];
             const item = {
-              uid: d.id.substr(1),
+              uid: d.id,
               name: d.name,
               avatar: d.avatar
             };

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskComments.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskComments.vue
@@ -75,6 +75,7 @@
             v-model="editorData"
             :max-length="MESSAGE_MAX_LENGTH"
             :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)"
+            :task="task"
             class="subComment subCommentEditor"
             @subShowEditor="openEditor"/>
           <v-btn
@@ -124,8 +125,8 @@
             }
           },
           task: {
-            type: Boolean,
-            default: false
+            type: Object,
+            default: () => null
           },
           sub: {
             type: Boolean,

--- a/task-management/src/main/webapp/vue-app/taskDrawer/taskDrawerApi.js
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/taskDrawerApi.js
@@ -246,15 +246,16 @@ export function removeTaskComment(commentId) {
 }
 
 export function findUsersToMention(projectId, query) {
-  return fetch(`/portal/rest/projects/users/${projectId}/${query}`, {
+  const fetchUrl = projectId ? `/portal/rest/projects/projectParticipants/${projectId}/${query}`
+      : `/portal/rest/tasks/usersToMention/${query}/${eXo.env.portal.language}`;
+  return fetch(fetchUrl, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {
-    if(resp && resp.ok) {
+    if (resp && resp.ok) {
       return resp.json();
-    }
-    else {
-      throw new Error ('Error when getting users to mention');
+    } else {
+      throw new Error('Error when getting users to mention');
     }
   })
 }

--- a/task-management/src/main/webapp/vue-app/taskDrawer/taskDrawerApi.js
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/taskDrawerApi.js
@@ -245,8 +245,8 @@ export function removeTaskComment(commentId) {
   })
 }
 
-export function findUsersToMention(query) {
-  return fetch(`/portal/rest/tasks/usersToMention/${query}/${eXo.env.portal.language}`, {
+export function findUsersToMention(projectId, query) {
+  return fetch(`/portal/rest/projects/users/${projectId}/${query}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {


### PR DESCRIPTION
Mentioning users in a task comment was fetching for all platform's users. We need to search for only participants of the project. As **participants** can be `users` or `spaces`, we will search for `space's members` that fits the mentioning query.