### PR TITLE
TASK-39937: clear labels input after closing task drawer (#184)

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -523,6 +523,7 @@
         this.showEditor=false;
         this.task={};
         document.dispatchEvent(new CustomEvent('drawerClosed'));
+        document.dispatchEvent(new CustomEvent('loadTaskLabels', {detail: {}}));
       },
       deleteTask() {
         this.deleteConfirmMessage = `${this.$t('popup.msg.deleteTask')} : <strong>${this.task.title}</strong>? `;


### PR DESCRIPTION
(cherry picked from commit 2608da0328463990f7d1c13e2e0cc640adaff968)
(cherry picked from commit a18c7eb4e6df2c56a905a9a675b91f37091ed0ab)