### PR TITLE
TASK-39378: implement filter by assignee in tasks dashboard

### DIFF
--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -490,7 +490,7 @@ public class TestProjectRestService {
     when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME,"userA")).thenReturn(userAIdentity);
 
     //when
-    Response response = projectRestService.getProjectParticipants(1L, "userA");
+    Response response = projectRestService.getProjectParticipants(1L, "userA", false);
 
     //then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
@@ -73,7 +73,7 @@
           for (let i = 0; i < data.length; i++) {
             const d = data[i];
             const item = {
-              uid: d.id,
+              uid: d.id.substr(1),
               name: d.name,
               avatar: d.avatar
             };

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -82,6 +82,7 @@
                       ref="autoFocusInput3"
                       :labels="suggesterLabels"
                       v-model="assignee"
+                      :search-options="searchOptions"
                       name="assignee"
                       type-of-relations="user_to_invite"
                       height="40"
@@ -234,7 +235,18 @@
           placeholder: this.$t('label.assignee'),
           noDataLabel: this.$t('label.noDataLabel'),
         };
-      }
+      },
+      searchOptions() {
+        if(this.project) {
+          const options = {
+            includeCurrentUser: true,
+          };
+          return {
+            searchUrl: '/portal/rest/projects/projectParticipants/'.concat(this.project).concat('/'),
+            options: options
+          };
+        }
+      },
     },
     created() {
       this.$root.$on('filter-task-labels',labels =>{


### PR DESCRIPTION
The problem is that the assignee filter suggester has not the projects rest API as an attribute.
Also in order to add the current user to the assignee filter input, we need to modify the **rest** `/projectParticipants` to return him with the list of project's participants.