### PR TITLE
Task-39437: Filtering by labels doesn't work on mobile tasks app

### DIFF
--- a/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
@@ -54,7 +54,7 @@ public class LabelServiceImpl implements LabelService {
     @Override
     @ExoTransactional
     public LabelDto createLabel(LabelDto label) {
-        return labelStorage.createLabel(labelStorage.labelToDto(daoHandler.getLabelHandler().create(labelStorage.labelToEntity(label))));
+        return labelStorage.createLabel(label);
     }
 
     @Override

--- a/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
@@ -128,7 +128,7 @@ public class LabelServiceTest {
         LabelDto label = TestUtils.getDefaultLabel();
         when(daoHandler.getLabelHandler().create(any())).thenReturn(labelStorage.labelToEntity(label));
         labelService.createLabel(label);
-        verify(labelHandler, times(2)).create(labelCaptor.capture());
+        verify(labelHandler, times(1)).create(labelCaptor.capture());
         Label result = labelCaptor.getValue();
         assertEquals("TODO", result.getName());
         assertEquals("label", result.getUsername());

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -270,6 +270,7 @@
       searchTasks(tasks) {
         if(!tasks){
          tasks = this.filterTasks;
+          this.labels=[];
         }
         this.loadingTasks = true;
         if(tasks.assignee){


### PR DESCRIPTION
This PR will fix the filtering by labels, when we create a new label, it will be created twice, this PR fix this problem, also it fixes the reset button in the filter by labels 