### PR TITLE
TASK-40708: Fix Wrong display of filter by status

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -70,8 +70,9 @@
                       <option
                         v-for="item in statusList"
                         :key="item.id"
-                        :value="item.id">
-                        {{ $t('label.status.'+item.name.toLowerCase()) }}
+                        :value="item.id"
+                        class="text-capitalize">
+                        {{ statusFilterLabel(item.name) }}
                       </option>
                     </select>
 
@@ -404,6 +405,13 @@
             localStorage.setItem(`filterStorage${value.projectId}`,JSON.stringify(value));
           }
         });
+      },
+      statusFilterLabel(item) {
+        if(this.$t(`label.status.${item.toLowerCase()}`).includes('label.status')) {
+          return item;
+        } else {
+          return this.$t(`label.status.${item.toLowerCase()}`);
+        }
       },
 
     }


### PR DESCRIPTION
**Problem** When we add a new status we wrongly display the label name `(Label.status.NewStatusName).`
**Solution** We check if the labels' name is new, we apply internationalization only for the old labels' name.