### PR TITLE
42544 : Fix problem of getting comments when comment text includes % …

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
@@ -63,6 +63,8 @@ public class TaskRestService implements ResourceContainer {
 
   private CommentStorage   commentStorage;
 
+  private static final String PERCENT_ENCODED_REGEX = "%(?![0-9a-fA-F]{2})";
+
   public TaskRestService(TaskService taskService,
                          CommentService commentService,
                          ProjectService projectService,
@@ -645,6 +647,7 @@ public class TaskRestService implements ResourceContainer {
     if (!TaskUtil.hasEditPermission(task)) {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
+    commentText = commentText.replaceAll(PERCENT_ENCODED_REGEX, "%25");
     commentText = URLDecoder.decode(commentText, "UTF-8");
     CommentDto addedComment = commentService.addComment(task, currentUser, commentText);
     if (addedComment != null) {
@@ -681,6 +684,7 @@ public class TaskRestService implements ResourceContainer {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
 
+    commentText = commentText.replaceAll(PERCENT_ENCODED_REGEX, "%25");
     commentText = URLDecoder.decode(commentText, "UTF-8");
     CommentDto addedComment = commentService.addComment(task, commentId, currentUser, commentText);
     if (addedComment != null) {


### PR DESCRIPTION
…character (#435)

when a commenty includes the % character , the comment is not retrieved correctly.
This fix will replace all % characters with their PERCENT encoded value before executing URLDecoder.decode() function.

(cherry picked from commit e36bc8f6fed5572eea449162b61d80aed68a5adf)