### PR TITLE
45017 : fix NPE when user is not found

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -316,36 +316,39 @@ public class ProjectRestService implements ResourceContainer {
 
     if (projectManagers.size() > 0) {
       for (String permission : projectService.getManager(projectId)) {
-        int index = permission.indexOf(':');
-        if (index > -1) {
-          String groupId = permission.substring(index + 1);
-          space = spaceService.getSpaceByGroupId(groupId);
-          if (space != null) {
-            managers.addAll(Arrays.asList(space.getManagers()));
-            JSONObject manager = new JSONObject();
-            manager.put("id", "space:" + space.getPrettyName());
-            manager.put("remoteId", space.getPrettyName());
-            manager.put("providerId", "space");
-            JSONObject profile = new JSONObject();
-            profile.put("fullName", space.getDisplayName());
-            profile.put("originalName", space.getPrettyName());
-            profile.put("avatarUrl", "/portal/rest/v1/social/spaces/" + space.getPrettyName() + "/avatar");
-            manager.put("profile", profile);
-            managersDetail.put(manager);
-          }
-        } else {
-          User user_ = UserUtil.getUser(permission);
-          if (user_ != null) {
-            managers.add(permission);
-            JSONObject manager = new JSONObject();
-            manager.put("id", "organization:" + permission);
-            manager.put("remoteId", permission);
-            manager.put("providerId", "organization");
-            JSONObject profile = new JSONObject();
-            profile.put("fullName", user_.getDisplayName());
-            profile.put("avatarUrl", user_.getAvatar());
-            manager.put("profile", profile);
-            managersDetail.put(manager);
+        if (permission != null) {
+          int index = permission.indexOf(':');
+          if (index > -1) {
+            String groupId = permission.substring(index + 1);
+            space = spaceService.getSpaceByGroupId(groupId);
+            if (space != null) {
+              managers.addAll(Arrays.asList(space.getManagers()));
+              JSONObject manager = new JSONObject();
+              manager.put("id", "space:" + space.getPrettyName());
+              manager.put("remoteId", space.getPrettyName());
+              manager.put("providerId", "space");
+              JSONObject profile = new JSONObject();
+              profile.put("fullName", space.getDisplayName());
+              profile.put("originalName", space.getPrettyName());
+              profile.put("avatarUrl", "/portal/rest/v1/social/spaces/" + space.getPrettyName() + "/avatar");
+              manager.put("profile", profile);
+              managersDetail.put(manager);
+            }
+
+          } else {
+            User user_ = UserUtil.getUser(permission);
+            if (user_ != null) {
+              managers.add(permission);
+              JSONObject manager = new JSONObject();
+              manager.put("id", "organization:" + permission);
+              manager.put("remoteId", permission);
+              manager.put("providerId", "organization");
+              JSONObject profile = new JSONObject();
+              profile.put("fullName", user_.getDisplayName());
+              profile.put("avatarUrl", user_.getAvatar());
+              manager.put("profile", profile);
+              managersDetail.put(manager);
+            }
           }
         }
       }
@@ -353,38 +356,40 @@ public class ProjectRestService implements ResourceContainer {
 
     if (projectParticipators.size() > 0 && participatorParam) {
       for (String permission : projectParticipators) {
-        int index = permission.indexOf(':');
-        if (index > -1) {
-          String groupId = permission.substring(index + 1);
-          Space spaceP = spaceService.getSpaceByGroupId(groupId);
-          if (spaceP != null) {
-            participators.addAll(Arrays.asList(spaceP.getMembers()));
-            JSONObject participator = new JSONObject();
-            participator.put("id", "space:" + spaceP.getPrettyName());
-            participator.put("remoteId", spaceP.getPrettyName());
-            participator.put("providerId", "space");
-            JSONObject profile = new JSONObject();
-            profile.put("fullName", spaceP.getDisplayName());
-            profile.put("originalName", spaceP.getPrettyName());
-            profile.put("avatarUrl", "/portal/rest/v1/social/spaces/" + spaceP.getPrettyName() + "/avatar");
-            participator.put("profile", profile);
-            participatorsDetail.put(participator);
+        if (permission != null) {
+          int index = permission.indexOf(':');
+          if (index > -1) {
+            String groupId = permission.substring(index + 1);
+            Space spaceP = spaceService.getSpaceByGroupId(groupId);
+            if (spaceP != null) {
+              participators.addAll(Arrays.asList(spaceP.getMembers()));
+              JSONObject participator = new JSONObject();
+              participator.put("id", "space:" + spaceP.getPrettyName());
+              participator.put("remoteId", spaceP.getPrettyName());
+              participator.put("providerId", "space");
+              JSONObject profile = new JSONObject();
+              profile.put("fullName", spaceP.getDisplayName());
+              profile.put("originalName", spaceP.getPrettyName());
+              profile.put("avatarUrl", "/portal/rest/v1/social/spaces/" + spaceP.getPrettyName() + "/avatar");
+              participator.put("profile", profile);
+              participatorsDetail.put(participator);
+            } else {
+              projectParticipators.remove(permission);
+            }
           } else {
-            projectParticipators.remove(permission);
-          }
-        } else {
-          User user_ = UserUtil.getUser(permission);
-          if (user_ != null) {
-            participators.add(permission);
-            JSONObject participator = new JSONObject();
-            participator.put("id", "organization:" + permission);
-            participator.put("remoteId", permission);
-            participator.put("providerId", "organization");
-            JSONObject profile = new JSONObject();
-            profile.put("fullName", user_.getDisplayName());
-            profile.put("avatarUrl", user_.getAvatar());
-            participator.put("profile", profile);
-            participatorsDetail.put(participator);
+            User user_ = UserUtil.getUser(permission);
+            if (user_ != null) {
+              participators.add(permission);
+              JSONObject participator = new JSONObject();
+              participator.put("id", "organization:" + permission);
+              participator.put("remoteId", permission);
+              participator.put("providerId", "organization");
+              JSONObject profile = new JSONObject();
+              profile.put("fullName", user_.getDisplayName());
+              profile.put("avatarUrl", user_.getAvatar());
+              participator.put("profile", profile);
+              participatorsDetail.put(participator);
+            }
           }
         }
       }

--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -334,17 +334,19 @@ public class ProjectRestService implements ResourceContainer {
             managersDetail.put(manager);
           }
         } else {
-          managers.add(permission);
           User user_ = UserUtil.getUser(permission);
-          JSONObject manager = new JSONObject();
-          manager.put("id", "organization:" + permission);
-          manager.put("remoteId", permission);
-          manager.put("providerId", "organization");
-          JSONObject profile = new JSONObject();
-          profile.put("fullName", user_.getDisplayName());
-          profile.put("avatarUrl", user_.getAvatar());
-          manager.put("profile", profile);
-          managersDetail.put(manager);
+          if (user_ != null) {
+            managers.add(permission);
+            JSONObject manager = new JSONObject();
+            manager.put("id", "organization:" + permission);
+            manager.put("remoteId", permission);
+            manager.put("providerId", "organization");
+            JSONObject profile = new JSONObject();
+            profile.put("fullName", user_.getDisplayName());
+            profile.put("avatarUrl", user_.getAvatar());
+            manager.put("profile", profile);
+            managersDetail.put(manager);
+          }
         }
       }
     }
@@ -371,17 +373,19 @@ public class ProjectRestService implements ResourceContainer {
             projectParticipators.remove(permission);
           }
         } else {
-          participators.add(permission);
           User user_ = UserUtil.getUser(permission);
-          JSONObject participator = new JSONObject();
-          participator.put("id", "organization:" + permission);
-          participator.put("remoteId", permission);
-          participator.put("providerId", "organization");
-          JSONObject profile = new JSONObject();
-          profile.put("fullName", user_.getDisplayName());
-          profile.put("avatarUrl", user_.getAvatar());
-          participator.put("profile", profile);
-          participatorsDetail.put(participator);
+          if (user_ != null) {
+            participators.add(permission);
+            JSONObject participator = new JSONObject();
+            participator.put("id", "organization:" + permission);
+            participator.put("remoteId", permission);
+            participator.put("providerId", "organization");
+            JSONObject profile = new JSONObject();
+            profile.put("fullName", user_.getDisplayName());
+            profile.put("avatarUrl", user_.getAvatar());
+            participator.put("profile", profile);
+            participatorsDetail.put(participator);
+          }
         }
       }
 

--- a/services/src/main/java/org/exoplatform/task/rest/model/TaskEntity.java
+++ b/services/src/main/java/org/exoplatform/task/rest/model/TaskEntity.java
@@ -63,8 +63,8 @@ public class TaskEntity {
     this.commentCount = commentCount;
     this.assignee = UserUtil.getUser(task.getAssignee());
     this.createdBy = UserUtil.getUser(task.getCreatedBy());
-    if(task.getCoworker()!=null) this.coworker = task.getCoworker().stream().map(user -> UserUtil.getUser(user)).collect(Collectors.toList());
-    if(task.getWatcher()!=null) this.watcher = task.getWatcher().stream().map(user -> UserUtil.getUser(user)).collect(Collectors.toList());
+    if(task.getCoworker()!=null) this.coworker = task.getCoworker().stream().map(UserUtil::getUser).collect(Collectors.toList());
+    if(task.getWatcher()!=null) this.watcher = task.getWatcher().stream().map(UserUtil::getUser).collect(Collectors.toList());
   }
 
 }

--- a/services/src/main/java/org/exoplatform/task/util/UserUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/UserUtil.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.Group;
@@ -146,7 +147,7 @@ public final class UserUtil {
   }
 
   public static org.exoplatform.task.model.User getUser(String userName){
-    if(userName==null) return null;
+    if(StringUtils.isBlank(userName)) return null;
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
     org.exoplatform.social.core.identity.model.Identity id = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME,userName);
     if(id==null){

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -233,6 +233,15 @@ public class TestProjectRestService {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertNotNull(response.getEntity());
 
+    when(projectService.getManager(1)).thenReturn(new HashSet<>(Arrays.asList(null, "")));
+    when(projectService.getParticipator(1)).thenReturn(new HashSet<>(Arrays.asList(null, "")));
+
+    // When
+    response = projectRestService.getProjectById(1,true);
+    // Then
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertNotNull(response.getEntity());
+
   }
 
   @Test


### PR DESCRIPTION
Sometimes, we have manager or participator in projects with Null , empty or not found identities, which caused NPE thrown and the project list is not retrived when trying to change a task's project.
The fix added checks for nullity on user object before using it.