### PR TITLE
TASK-46980 : fixed wrong task link proposed to user when opening a specific task from the notification drawer

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -47,7 +47,6 @@ export default {
       spaceName: '',
       projectId: '',
       alert: false,
-      callEvent: true,
       type: '',
       message: '',
       task: {
@@ -55,6 +54,11 @@ export default {
         default: () => ({}),
       }
     };
+  },
+  computed: {
+    isDrawerClosed() {
+      return this.$refs.taskDrawer.$refs.addTaskDrawer.drawer===false;
+    }
   },
   created(){
     this.$root.$on('show-alert', message => {
@@ -71,14 +75,12 @@ export default {
 
       if (context.type==='task'){
         this.setTaskUrl(context.id);
-        this.callEvent = false;
       }
-      if (context.type==='project' && this.callEvent===true){
+      if (context.type==='project' && this.isDrawerClosed ){
         this.setProjectUrl(context.id);
       }
       if (context.type==='myProjects'){
         this.getMyProjects();
-        this.callEvent = true;
       }
     });
     this.$root.$on('open-task-drawer', task => {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -47,6 +47,7 @@ export default {
       spaceName: '',
       projectId: '',
       alert: false,
+      callEvent: true,
       type: '',
       message: '',
       task: {
@@ -70,12 +71,14 @@ export default {
 
       if (context.type==='task'){
         this.setTaskUrl(context.id);
+        this.callEvent = false;
       }
-      if (context.type==='project'){
+      if (context.type==='project' && this.callEvent===true){
         this.setProjectUrl(context.id);
       }
       if (context.type==='myProjects'){
         this.getMyProjects();
+        this.callEvent = true;
       }
     });
     this.$root.$on('open-task-drawer', task => {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -57,7 +57,7 @@ export default {
   },
   computed: {
     isDrawerClosed() {
-      return this.$refs.taskDrawer.$refs.addTaskDrawer.drawer===false;
+      return !this.$refs.taskDrawer.$refs.addTaskDrawer.drawer;
     }
   },
   created(){


### PR DESCRIPTION
before this fix , when opening a task notification from the notification drawer , the url bar is pointing to the project link instead of the task link so i fixed this issue by controlling the handling of the set-url event which is fired twice in a row when launching the multiple tasks portlets causing a wrong url . 