### PR TITLE
Task-45628 Enhance draggable cards in tasks view board

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app
     id="taskCardItem"
+    class="taskBoardCardItem"
     :class="removeCompletedTask && 'completedTask' || ''">
     <v-card
       :class="[getTaskPriorityColor(task.task.priority)]"

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
@@ -10,7 +10,6 @@
               :move="checkMoveStatus"
               :list="statusList"
               :animation="200"
-              group="people"
               ghost-class="ghost-card"
               class="d-flex"
               @start="dragStatus=true"

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
@@ -26,9 +26,10 @@
       v-model="tasksList"
       :move="checkMove"
       :animation="200"
-      group="people"
       ghost-class="ghost-card"
       class="draggable-palceholder taskBoardColumn"
+      handle=".taskBoardCardItem"
+      :group="{ name: 'status' }"
       :class="filterNoActive && 'taskBoardNoFilterColumn'"
       @start="drag=true"
       @end="drag=false">

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
@@ -14,7 +14,6 @@
           v-model="tasksList"
           :move="checkMove"
           :animation="200"
-          group="people"
           class="draggable-palceholder"
           ghost-class="ghost-card"
           @start="drag=true"


### PR DESCRIPTION
In Tasks Board view when dragging cards from status to another, sometimes a new status column added (bug) because status columns are also draggable (we have a draggable child inside a draggable parent), so in this PR we try to fix the draggable group option in the child component to avoid create a new column for parent.
[Related Task](https://community.exoplatform.com/portal/dw/tasks/taskDetail/45628)