### PR TITLE
Task47590 : Task comment button is not disabled if character limit is exceeded.

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
@@ -83,6 +83,7 @@ export default {
       charsCount: 0,
       disabledComment: '',
       currentUserName: eXo.env.portal.userName,
+      MESSAGE_MAX_LENGTH: 1250,
       currentCommentId: ''
     };
   },


### PR DESCRIPTION
Task47590: Before this fix, if the number of characters of comments is more than 1250 characters, the comment button is not disabled. This fix will ensure that the button is well disabled if the character's limit is exceeded.