### PR TITLE
TASK-47590: The task comment button is not disabled if the character limit is exceeded

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentEditor.vue
@@ -82,6 +82,7 @@ export default {
       inputVal: this.value,
       charsCount: 0,
       disabledComment: '',
+      MESSAGE_MAX_LENGTH: 1250,
       currentUserName: eXo.env.portal.userName,
       currentCommentId: ''
     };


### PR DESCRIPTION
TASK-47590: The task comment button is not disabled if the character limit is exceeded.

This PR will fix the problem of the task comments button is disabled when the number of characters is more than 1250 
characters. The problem is due to the lack of the variable MESSAGE_MAX_LENGTH on TaskCommentEditor.vue.