### PR TITLE
TASK-46980 : fixed wrong task link proposed to user when opening a specific task from the notification drawer

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -55,6 +55,11 @@ export default {
       }
     };
   },
+  computed: {
+    isDrawerClosed() {
+      return !this.$refs.taskDrawer.$refs.addTaskDrawer.drawer;
+    }
+  },
   created(){
     this.$root.$on('show-alert', message => {
       this.displayMessage(message);
@@ -71,7 +76,7 @@ export default {
       if (context.type==='task'){
         this.setTaskUrl(context.id);
       }
-      if (context.type==='project'){
+      if (context.type==='project' && this.isDrawerClosed ){
         this.setProjectUrl(context.id);
       }
       if (context.type==='myProjects'){


### PR DESCRIPTION
before this fix , when opening a task notification from the notification drawer , the url bar is pointing to the project link instead of the task link so i fixed this issue by controlling the handling of the set-url event which is fired twice in a row when launching the multiple tasks portlets causing a wrong url . 