### PR TITLE
Task-48275 : Console errors when opening the task drawer

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -20,7 +20,7 @@
             v-if="taskAssigneeObj && taskAssigneeObj.profile && taskAssigneeObj.profile.fullName" 
             class="assigneeName">
             <exo-user-avatar
-              :username="taskAssigneeObj.profile.remoteId"
+              :username="taskAssigneeObj.remoteId"
               :fullname="taskAssigneeFullName"
               :avatar-url="taskAssigneeObj.profile.avatarUrl"
               :title="taskAssigneeObj.profile.fullName"


### PR DESCRIPTION
Issue: console error when opening the task drawer, caused by taskAssigneeObj.profile.remoteId, the remoteId doesn't exit on profile.
Solution: taskAssigneeObj.remoteId gives the remoteId.