### PR TITLE
Task-48131: Cannot set a priority to a task

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskPriority.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskPriority.vue
@@ -100,7 +100,9 @@ export default {
     },
     updateTaskPriority() {
       this.priorityDefaultColor = this.getTaskPriorityColor(this.priority);
-      this.$emit('updateTaskPriority',this.priority);
+      this.$emit('updateTaskPriority',{
+        priority: this.priority
+      });
       window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
     },
   }


### PR DESCRIPTION
The event 'updateTaskPriority' receive in taskDrawer was with argument value.priority,so we should add the argument priority in emit event.