### PR TITLE
Task-44179: After cloning or deleting a task, tasks are displayed after a considerate waiting time.

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -714,7 +714,7 @@ export default {
           type: 'success',
           message: this.$t('alert.success.task.cloned') 
         });
-        this.$root.$emit('refresh-tasks-list');
+        this.$root.$emit('task-added', task);
         this.$root.$emit('open-task-drawer', task);
       }).catch(e => {
         console.error('Error when cloning task', e);
@@ -730,7 +730,9 @@ export default {
         method: 'DELETE',
         credentials: 'include',
       }).then( () => {
-        this.$root.$emit('refresh-tasks-list', this.task);
+        this.$root.$emit('deleteTask', {
+          detail: this.task.id
+        });
         this.$root.$emit('show-alert', {
           type: 'success',
           message: this.$t('alert.success.task.deleted') 


### PR DESCRIPTION
We don't need to load all lists of tasks, we need only to update the task updated.
This PR fix this problem.