### PR TITLE
TASK-48396: Filter Task list view by labels

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -345,7 +345,7 @@ export default {
         this.taskFilter.groupBy='';
         this.filterProjectActive=false;
         this.filterByStatus=true;
-        return this.$tasksService.filterTasksList(this.taskFilter,'','','',this.project.id).then(data => {
+        return this.$tasksService.filterTasksList(this.taskFilter,'','',e.filterLabels.labels,this.project.id).then(data => {
           this.filterProjectActive=false;
           this.filterByStatus=true;
           this.tasksList = data && data.tasks || [];


### PR DESCRIPTION
The problem was that the call for `filterTaskList` method was always without labels param.
This fix add the lables param to the method call when it's a case of grouped by `status` list view.