### PR TITLE
TASK-48435: Fix initializing participators and managers in adding a new project form

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
@@ -184,7 +184,7 @@ export default {
       if (this.$refs.invitedAttendeeAutoComplete) {
         this.$refs.invitedAttendeeAutoComplete.focus();
       }
-      this.$emit('initialized');
+      this.$root.$emit('task-project-manager',this.manager);
     },
     removeAttendee(attendee) {
       const index = this.manager.findIndex(addedAttendee => {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeParticipator.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeParticipator.vue
@@ -181,7 +181,7 @@ export default {
       if (this.$refs.invitedAttendeeAutoComplete){
         this.$refs.invitedAttendeeAutoComplete.focus();
       }
-      this.$emit('initialized');
+      this.$root.$emit('task-project-participator',this.participator);
     },
     removeAttendee(attendee) {
       const index = this.participator.findIndex(addedAttendee => {


### PR DESCRIPTION
The problem was that the initialization of participator or manager list in the sub child was not sent to the parent component `AddProjectDrawer`.
This fix should send an event when the lists are inialized.