### PR TITLE
Task-41258 : Log error when building the task URL

### DIFF
--- a/services/src/main/java/org/exoplatform/task/util/ResourceUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/ResourceUtil.java
@@ -142,6 +142,9 @@ public class ResourceUtil {
     NodeContext<?> page = null;
     NavigationService navService = container.getComponentInstanceOfType(NavigationService.class);
     NavigationContext ctx = navService.loadNavigation(siteKey);
+    if (ctx == null || ctx.getData() == null || ctx.getData().getRootId() == null) {
+      return "#";
+    }
     Scope scope;
     if (siteKey.getType().equals(SiteType.GROUP)) {
       scope = Scope.GRANDCHILDREN;


### PR DESCRIPTION
No specific scenario could be followed to reproduce this problem.
Prior this change, in some cases we have a null navigation context that caused a log error.
Fix : Add nullability test on navigation context before building the url.