### PR TITLE
TASK-48395: Filter tasks by assignee in Tasks Tab

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -252,7 +252,7 @@ export default {
           options: options
         };
       }
-      return '';
+      return {};
     },
   },
   created() {


### PR DESCRIPTION
The problem was that in case of tasks tab the `searchOptions` were returned as an empty string which caused a problem for the suggester component.
This fix should send an empty object to the suggester service, so it can be replaced with default values.