### PR TITLE
Task-48358: Fix assigning more than coworker on edit mode

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -591,7 +591,6 @@ export default {
           this.task.coworker = [];
         }
         this.$taskDrawerApi.updateTask(this.task.id, this.task).then( () => {
-          this.oldTask.coworker = this.task.coworker;
           this.$root.$emit('show-alert', {
             type: 'success',
             message: this.$t('alert.success.task.coworker')


### PR DESCRIPTION
**Problem:** When editing an existing task `this.oldTask.coworker` cannot give us the real value of coworkers in database in order to update task coworkers.
**Solution:** After updating coworker, we must not update `this.oldTask.coworker`, we must keep getting it only when open drawer