### PR TITLE
Task-46740: Fix initialization of taskFilter property.

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -202,7 +202,7 @@ export default {
       defaultAvatar: '/portal/rest/v1/social/users/default-image/avatar',
       keyword: null,
       loadingTasks: false,
-      taskFilter: null,
+      taskFilter: {},
       taskViewTabName: 'board',
       deleteConfirmMessage: null,
       statusList: [],
@@ -342,10 +342,14 @@ export default {
         }
       } else {
         this.getFilterProject(ProjectId, currentTab).then(() => {
-          this.tasksFilter.query = query;
-          this.tasksFilter.offset = 0;
-          this.tasksFilter.limit = 0;
-          this.tasksFilter.showCompleteTasks = false;
+          this.tasksFilter = {
+            query: query,
+            groupBy: '',
+            orderBy: '',
+            offset: 0,
+            limit: 0,
+            showCompleteTasks: false,
+          };
           
           if (this.taskFilter.groupBy === 'completed') {
             this.tasksFilter.showCompleteTasks = true;


### PR DESCRIPTION
The previous commit made a regression which makes it impossible to add a task or display the list of tasks due to the bad way of initializing the property.
These changes make sure to initialize properly the property taskFilter.
Once the Task-46740 is validated this commit will be squashed with the original commit.