### PR TITLE
Task-48769: Project creation under a space fails

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
@@ -264,7 +264,7 @@ export default {
           if (this.manager.filter(e => e.providerId === 'space').length > 0) {
             this.manager.forEach(manager_el => {
               if (manager_el.providerId ==='space') {
-                projects.spaceName=manager_el.profile.fullname;
+                projects.spaceName = eXo.env.portal.spaceName;
                 projects.manager.push(`manager:/spaces/${manager_el.remoteId}`);
                 projects.participator.push(`member:/spaces/${manager_el.remoteId}`);
               } else {


### PR DESCRIPTION
When you create a Space with a name containing a space, you cannot add a project to that space. To fix this problem, you need to use the PrettyName to find the space and not DisplayNname .