### PR TITLE
Task-46740: Make sure to update Task's card when the assignee or coworker are updated in list view.

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -181,6 +181,14 @@ export default {
       return this.task.task.completed === true && !this.showCompletedTasks;
     }
   },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+  },
   created() {
     this.$root.$on('update-completed-task', (value, id) => {
       if (this.task.id === id) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewListItem.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewListItem.vue
@@ -136,6 +136,14 @@ export default {
       return this.task.task.completed === true && !this.showCompletedTasks;
     }
   },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+  },
   created() {
     this.getTaskAssigneeAndCoworkers();
     this.$root.$on('update-completed-task',(value,id)=>{

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -162,6 +162,14 @@ export default {
       return this.task.task.completed === true && !this.showCompletedTasks;
     },
   },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+  },
   created() {
     this.$root.$on('update-completed-task', (value, id) => {
       if (this.task.id === id) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
@@ -194,6 +194,14 @@ export default {
       return this.task.task.completed === true && !this.showCompletedTasks;
     }
   },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+  },
   created() {
     this.$root.$on('update-completed-task',(value,id)=>{
       if (this.task.id === id){


### PR DESCRIPTION
Problem: when the task's assignee/coworker are updated the task card isn't updated since the assignee/coworker are generated only when the vue instance is created.
Fix: These changes adds a watch property on the attributes task.assignee and task.coworker to trigger any updates.