### PR TITLE
Task-46740: Avoid UI reloading when adding a new task, marking a task as completed, assigning a task or changing the priority.

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
@@ -196,7 +196,7 @@ public class TaskRestService implements ResourceContainer {
                               @ApiParam(value = "assignee term", required = false) @QueryParam("assignee") String assignee,
                               @ApiParam(value = "coworker term", required = false) @QueryParam("coworker") String coworker,
                               @ApiParam(value = "watchers term", required = false) @QueryParam("watcher") String watcher,
-                              @ApiParam(value = "showCompleted term", defaultValue = "false") @QueryParam("showCompleted") boolean showCompleted,
+                              @ApiParam(value = "showCompletedTasks term", defaultValue = "false") @QueryParam("showCompletedTasks") boolean showCompletedTasks,
                               @ApiParam(value = "statusId term", required = false) @QueryParam("statusId") String statusId,
                               @ApiParam(value = "space_group_id term", required = false) @QueryParam("space_group_id") String space_group_id,
                               @ApiParam(value = "groupBy term", required = false) @QueryParam("groupBy") String groupBy,
@@ -235,7 +235,7 @@ public class TaskRestService implements ResourceContainer {
       statusIdLong=statusDto.getId();
     }
     ViewState.Filter filter = new ViewState.Filter(listId);
-    filter.updateFilterData(filterLabelIds, statusId, dueDate, priority, assignee, coworker, watcher, showCompleted, query);
+    filter.updateFilterData(filterLabelIds, statusId, dueDate, priority, assignee, coworker, watcher, showCompletedTasks, query);
 
     ProjectDto project = null;
     boolean noProjPermission = false;
@@ -919,13 +919,13 @@ public class TaskRestService implements ResourceContainer {
           @ApiResponse(code = 400, message = "Invalid query input"), @ApiResponse(code = 403, message = "Unauthorized operation"),
           @ApiResponse(code = 404, message = "Resource not found") })
   public Response updateCompleted(@ApiParam(value = "Task id", required = true) @PathParam("idTask") long idTask,
-                                  @ApiParam(value = "showCompleteTasks", defaultValue = "false") @QueryParam("showCompleteTasks") boolean showCompleteTasks) {
+                                  @ApiParam(value = "isCompleted", defaultValue = "false") @QueryParam("isCompleted") boolean isCompleted) {
     try {
     TaskDto task = taskService.getTask(idTask);
     if (!TaskUtil.hasEditPermission(taskService,task)) {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
-    task.setCompleted(showCompleteTasks);
+    task.setCompleted(isCompleted);
     taskService.updateTask(task);
 
     return Response.ok(task).build();

--- a/task-management/src/main/webapp/js/taskDrawerApi.js
+++ b/task-management/src/main/webapp/js/taskDrawerApi.js
@@ -14,23 +14,27 @@ export function getUserInformations(userName) {
 }
 
 export function updateTask(taskId, task) {
-  document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-  return fetch(`/portal/rest/tasks/${taskId}`, {
-    method: 'PUT',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(task),
-  }).then(resp => {
-    if (!resp || !resp.ok) {
-      return resp.text().then((text) => {
-        throw new Error(text);
-      });
-    } else {
-      return resp.json();
-    }
-  }).finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
+  if (taskId) {
+    document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
+    return fetch(`/portal/rest/tasks/${taskId}`, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(task),
+    }).then(resp => {
+      if (!resp || !resp.ok) {
+        return resp.text().then((text) => {
+          throw new Error(text);
+        });
+      } else {
+        return resp.json();
+      }
+    }).finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
+  } else {
+    return Promise.resolve();
+  }
 }
 
 export function addTask(task) {

--- a/task-management/src/main/webapp/js/tasksService.js
+++ b/task-management/src/main/webapp/js/tasksService.js
@@ -14,9 +14,9 @@ export function getMyTasksList(type, query, offset, limit) {
   }).finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
 }
 
-export function filterTasksList(tasks, groupBy, sortBy, filterLabelIds, projectId) {
+export function filterTasksList(tasks, groupBy, orderBy, filterLabelIds, projectId) {
   document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-  return fetch(`${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/tasks/filter?projectId=${projectId || tasks.projectId || -2}&query=${tasks.query || ''}&dueDate=${tasks.dueDate || ''}&priority=${tasks.priority || ''}&statusId=${tasks.statusId || ''}&showCompleted=${tasks.showCompleteTasks || ''}&assignee=${tasks.assignee || ''}&watcher=${tasks.watcher || ''}&coworker=${tasks.coworker || ''}&groupBy=${groupBy || tasks.groupBy || ''}&orderBy=${sortBy || tasks.orderBy || ''}&dueCategory=${tasks.dueCategory || ''}&filterLabelIds=${filterLabelIds || tasks.filterLabelIds || ''}&offset=${tasks.offset || 0}&limit=${tasks.limit|| 0}`, {
+  return fetch(`${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/tasks/filter?projectId=${projectId || tasks.projectId || -2}&query=${tasks.query || ''}&dueDate=${tasks.dueDate || ''}&priority=${tasks.priority || ''}&statusId=${tasks.statusId || ''}&showCompletedTasks=${tasks.showCompletedTasks || ''}&assignee=${tasks.assignee || ''}&watcher=${tasks.watcher || ''}&coworker=${tasks.coworker || ''}&groupBy=${groupBy || tasks.groupBy || ''}&orderBy=${orderBy || tasks.orderBy || ''}&dueCategory=${tasks.dueCategory || ''}&filterLabelIds=${filterLabelIds || tasks.filterLabelIds || ''}&offset=${tasks.offset || 0}&limit=${tasks.limit|| 0}`, {
     method: 'GET',
     credentials: 'include',
   }).then(resp => {
@@ -97,7 +97,7 @@ export function getTasksByProjectId(projectId) {
 
 export function updateCompleted(task) {
   document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-  return fetch(`${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/tasks/updateCompleted/${task.id}?&showCompleteTasks=${task.showCompleteTasks}`, {
+  return fetch(`${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/tasks/updateCompleted/${task.id}?&isCompleted=${task.isCompleted}`, {
     headers: {
       'Content-Type': 'application/json'
     },

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -224,7 +224,6 @@ export default {
           };
         });
         this.$emit('updateTaskAssignment', this.currentUser);
-        window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
       }
     },
     setMeAsCoworker() {
@@ -263,7 +262,6 @@ export default {
             this.taskCoworkerObj.push(taskCoworker);
           }).then(() => {
             this.$emit('updateTaskCoworker',this.taskCoworkers );
-            window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
           });
         }
       }
@@ -273,12 +271,10 @@ export default {
         if (value.remoteId !== this.currentUser && this.task.assignee !== value.remoteId) {
           this.taskAssigneeObj = value;
           this.$emit('updateTaskAssignment', value.remoteId);
-          window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
         }
         else {
           if ( this.task.id ===null ) {
             this.$emit('updateTaskAssignment', this.taskAssigneeObj.remoteId);
-            window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
           }
         }
       }
@@ -289,19 +285,16 @@ export default {
           this.taskCoworkers.push(value[value.length-1].remoteId);
           this.$emit('updateTaskCoworker',this.taskCoworkers );
           this.taskCoworkerObj.push(value[value.length-1]);
-          window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
         }
       }
     },
     removeCoworker(value) {
       this.taskCoworkers.splice(this.taskCoworkers.findIndex(taskCoworker => taskCoworker === value.remoteId), 1);
       this.$emit('updateTaskCoworker',this.taskCoworkers);
-      window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
     },
     removeAssignee() {
       this.taskAssigneeObj = {};
       this.$emit('updateTaskAssignment', null);
-      window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
     },
   }
 };

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
@@ -281,7 +281,6 @@ export default {
       if (this.$refs.taskDueDate && this.$refs.taskDueDate.menu) {
         this.$refs.taskDueDate.menu = false;
       }
-      window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
     },
     resetStartDate() {
       this.startDate = null;
@@ -289,20 +288,17 @@ export default {
       if (this.$refs.taskStartDate && this.$refs.taskStartDate.menu) {
         this.$refs.taskStartDate.menu = false;
       }
-      window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
     },
     emitStartDate(date) {
       const newDate = this.toDateObject(date);
       if ((!date && this.actualTask.startDate) || (date && !this.actualTask.startDate) || (this.actualTask.startDate && !this.datesEquals(newDate,this.actualTask.startDate))) {
         this.$emit('startDateChanged',newDate);
-        window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
       }
     },
     emitDueDate(date) {
       const newDate = this.toDateObject(date);
       if ((!date && this.actualTask.dueDate) || (date && !this.actualTask.dueDate) || (this.actualTask.dueDate && !this.datesEquals(newDate,this.actualTask.dueDate))) {
         this.$emit('dueDateChanged',newDate);
-        window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
       }
     },
     datesEquals(date1,date2){

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskPriority.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskPriority.vue
@@ -100,10 +100,11 @@ export default {
     },
     updateTaskPriority() {
       this.priorityDefaultColor = this.getTaskPriorityColor(this.priority);
-      this.$emit('updateTaskPriority',{
-        priority: this.priority
-      });
-      window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
+      const value = {
+        'priority': this.priority,
+        'taskId': this.task.id,
+      };
+      this.$emit('updateTaskPriority',value);
     },
   }
 };

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TasksStatus.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TasksStatus.vue
@@ -48,23 +48,10 @@ export default {
         }, 100);
       }
     });
-    document.addEventListener('loadProjectStatus', event => {
-      if (event && event.detail) {
-        const task = event.detail;
-        if (task.status!= null && task.status.project) {
-          this.getStatusesByProjectId(task);
-          if (task.status.name) {
-            this.taskStatus = task.status.name;
-          }
-        } else {
-          this.projectStatuses.push({key: 'ToDo', value: this.$t('exo.tasks.status.todo')});
-          this.projectStatuses.push({key: 'InProgress', value: this.$t('exo.tasks.status.inprogress')});
-          this.projectStatuses.push({key: 'WaitingOn', value: this.$t('exo.tasks.status.waitingon')});
-          this.projectStatuses.push({key: 'Done', value: this.$t('exo.tasks.status.done')});
-          this.taskStatus = 'ToDo';
-        }
-      }
-    });
+    document.addEventListener('loadProjectStatus', this.loadProjectStatus);
+  },
+  destroyed() {
+    document.removeEventListener('loadProjectStatus', this.loadProjectStatus);
   },
   methods: {
     updateTaskStatus() {
@@ -74,9 +61,7 @@ export default {
             const status = projectStatuses.find(s => s.name === this.taskStatus);
             this.task.status = status;
             this.$emit('updateTaskStatus',status);
-          }).finally(() => {
-          window.setTimeout(() => this.$root.$emit('refresh-tasks-list'), 200);
-        });
+          });
       }
     },
     getStatusesByProjectId(task) {
@@ -102,6 +87,23 @@ export default {
             }
           }
         });
+    },
+    loadProjectStatus(event) {
+      if (event && event.detail) {
+        const task = event.detail;
+        if (task.status != null && task.status.project) {
+          this.getStatusesByProjectId(task);
+          if (task.status.name) {
+            this.taskStatus = task.status.name;
+          }
+        } else {
+          this.projectStatuses.push({key: 'ToDo', value: this.$t('exo.tasks.status.todo')});
+          this.projectStatuses.push({key: 'InProgress', value: this.$t('exo.tasks.status.inprogress')});
+          this.projectStatuses.push({key: 'WaitingOn', value: this.$t('exo.tasks.status.waitingon')});
+          this.projectStatuses.push({key: 'Done', value: this.$t('exo.tasks.status.done')});
+          this.taskStatus = 'ToDo';
+        }
+      }
     },
   }
 };

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectDashboard.vue
@@ -47,7 +47,6 @@ export default {
       if (event && event.detail) {
         this.project =  event.detail;
         window.setTimeout(() => {
-          //this.displayDetails = true;
           this.$root.$emit('set-url', {type: 'project',id: this.project.id});
         }, 200);
       }

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/QuickAddCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/QuickAddCard.vue
@@ -66,9 +66,9 @@ export default {
     addTask() {
       this.newTask.title=this.taskTitle;
       this.newTask.status=this.status;
-      this.$taskDrawerApi.addTask(this.newTask).then( () => {
+      this.$taskDrawerApi.addTask(this.newTask).then( addedTask => {
         this.closeForm();
-        this.$root.$emit('refresh-tasks-list', this.task);
+        this.$root.$emit('task-added', addedTask);
         this.$root.$emit('show-alert', {
           type: 'success',
           message: this.$t('alert.success.task.created')

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -140,8 +140,6 @@ export default {
       isPersonnalTask: this.task.task.status === null,
       drawer: null,
       maxAvatarToShow: 1,
-      showCompleteTasks: false,
-      removeCompletedTask: false
     };
   },
   computed: {
@@ -179,26 +177,24 @@ export default {
         return 'taskNonePriority';
       }
     },
-  },
-  watch: {
-    taskCompletedClass: {
-      immediate: true,
-      handler() {
-        if (this.taskCompletedClass === 'uiIconValidate') {
-          this.showCompleteTasks = false;
-        } else {
-          this.showCompleteTasks = true;
-        }     
-      }
+    removeCompletedTask() {
+      return this.task.task.completed === true && !this.showCompletedTasks;
     }
   },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+  },
   created() {
-    this.$root.$on('update-completed-task',(value,id)=>{
-      if (this.task.id === id){
-        this.task.task.completed=value;
-        if (this.task.task.completed === true && !this.showCompletedTasks){
+    this.$root.$on('update-completed-task', (value, id) => {
+      if (this.task.id === id) {
+        this.task.task.completed = value;
+        if (this.task.task.completed === true && !this.showCompletedTasks) {
           this.$emit('update-task-completed', this.task.task);
-          this.removeCompletedTask = true;
         }
       }
     });
@@ -317,33 +313,28 @@ export default {
       this.drawer = drawer;
     },
     updateCompleted() {
-
       const task = {
         id: this.task.task.id,
-        showCompleteTasks: this.showCompleteTasks,
+        isCompleted: !this.task.task.completed,
       };
-
-
+      
       if (task.id) {
-        return this.$tasksService.updateCompleted(task).then(task => {
-          if (task.completed){
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.completed')});   
+        return this.$tasksService.updateCompleted(task).then(updatedTask => {
+          if (updatedTask.completed) {
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.completed')});
           } else {
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.unCompleted')});
-          }           
-          this.$emit('update-task-completed', task);
-          if ( task.completed === true && !this.showCompletedTasks) {
-            this.removeCompletedTask = true;
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.unCompleted')});
           }
-        }).then(this.task.task.completed = task.showCompleteTasks)
-          .catch(e => {
-            console.error('Error updating project', e);
-            this.$root.$emit('show-alert', {
-              type: 'error',
-              message: this.$t('alert.error')
-            });
-            this.postProject = false;
+          this.$emit('update-task-completed', updatedTask);
+          this.task.task.completed = task.isCompleted;
+        }).catch(e => {
+          console.error('Error updating project', e);
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t('alert.error')
           });
+          this.postProject = false;
+        });
       }
 
 

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksUnscheduledDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksUnscheduledDrawer.vue
@@ -39,7 +39,8 @@
       <task-view-card
         v-for="taskItem in filtredTasks"
         :key="taskItem.task.id"
-        :task="taskItem" />
+        :task="taskItem"
+        :show-completed-tasks="showCompletedTasks" />
     </template>
     <template v-else slot="content">
       <div class="noUnscheduledTasksFound">
@@ -55,7 +56,11 @@ export default {
     project: {
       type: String,
       default: ''
-    }
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false
+    },
   },
   data: () => ({
     unscheduledTasks: [],

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
@@ -25,7 +25,7 @@
                   class="draggable-palceholder"
                   :tasks-list="getTasksByStatus(tasksList,status.name)"
                   :index="index"
-                  :show-completed-tasks="filterTaskCompleted"
+                  :show-completed-tasks="showCompletedTasks"
                   :status-list-length="statusList.length"
                   :filter-no-active="filterNoActive"
                   @updateTaskCompleted="updateTaskCompleted"
@@ -50,7 +50,7 @@
                 :status="status"
                 :tasks-list="getTasksByStatus(tasksList,status.name)"
                 :index="index"
-                :show-completed-tasks="filterTaskCompleted"
+                :show-completed-tasks="showCompletedTasks"
                 :status-list-length="statusList.length"
                 :filter-no-active="filterNoActive"
                 @updateTaskCompleted="updateTaskCompleted"
@@ -83,14 +83,14 @@ export default {
       type: Number,
       default: 0
     },
-    filterTaskCompleted: {
+    showCompletedTasks: {
       type: Boolean,
       default: false
     },
     filterNoActive: {
       type: Boolean,
       default: false
-    }
+    },
   },
   data() {
     return {
@@ -134,7 +134,7 @@ export default {
       return tasksByStatus;
     },
     updateTaskCompleted(e){
-      if ( !this.filterTaskCompleted ) {
+      if ( !this.showCompletedTasks ) {
         this.$root.$emit('update-task-completed', e);
       }
     },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
@@ -125,10 +125,8 @@ export default {
     },
     updateTaskCompleted(task) {
       if (!this.showCompletedTasks && task.completed) {
-        const index = this.tasksList.findIndex(taskEl => taskEl.id === task.id);
-        this.tasksList.splice(index, 1);
         setTimeout(() => {
-          this.reRenderTasks();
+          this.$root.$emit('task-isCompleted-updated', task);
         }, 500);
       }
     },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -26,6 +26,7 @@
           :task-card-tab-view="'#tasks-view-board'"
           :task-list-tab-view="'#tasks-view-list'"
           :task-gantt-tab-view="'#tasks-view-gantt'"
+          :show-completed-tasks="showCompletedTasks"
           @keyword-changed="filterByKeyword"
           @taskViewChangeTab="getChangeTabValue"
           @filter-task-dashboard="filterTaskDashboard"
@@ -123,6 +124,7 @@
               :project="project"
               :status-list="statusList"
               :tasks-list="tasksList[i]"
+              :show-completed-tasks="showCompletedTasks"
               @update-status="updateStatus"
               @create-status="createStatus"
               @move-status="moveStatus"
@@ -134,7 +136,8 @@
             <tasks-view-list
               :project="project"
               :status-list="statusList"
-              :tasks-list="tasksList[i]" />
+              :tasks-list="tasksList[i]"
+              :show-completed-tasks="showCompletedTasks" />
           </div>
         </div>
       </div>
@@ -150,7 +153,7 @@
           :project="project" 
           :status-list="statusList"
           :tasks-list="tasksList"
-          :filter-task-completed="filterAsCompleted"
+          :show-completed-tasks="showCompletedTasks"
           :filter-no-active="true"
           @update-status="updateStatus"
           @create-status="createStatus"
@@ -164,7 +167,7 @@
           :project="project"
           :status-list="statusList"
           :tasks-list="tasksList"
-          :filter-task-completed="filterAsCompleted"
+          :show-completed-tasks="showCompletedTasks"
           :filter-by-status="filterByStatus=true"
           @update-status="updateStatus" />
       </div>
@@ -186,7 +189,9 @@
         {{ $t('spacesList.button.showMore') }}
       </v-btn>
     </div>
-    <tasks-unscheduled-drawer :project="project" />
+    <tasks-unscheduled-drawer 
+      :project="project"
+      :show-completed-tasks="showCompletedTasks" />
   </v-app>
 </template>
 <script>
@@ -202,7 +207,7 @@ export default {
       defaultAvatar: '/portal/rest/v1/social/users/default-image/avatar',
       keyword: null,
       loadingTasks: false,
-      taskFilter: null,
+      tasksFilter: {},
       taskViewTabName: 'board',
       deleteConfirmMessage: null,
       statusList: [],
@@ -212,11 +217,31 @@ export default {
       filterProjectActive: true,
       filterByStatus: false,
       status: null,
-      filterAsCompleted: false,
+      showCompletedTasks: false,
     };
   },
   watch: {
     project() {
+      if (localStorage.getItem(`filterStorage${this.project.id}+${this.taskViewTabName}`)) {
+        const projectFilter = JSON.parse(localStorage.getItem(`filterStorage${this.project.id}+${this.taskViewTabName}`));
+        this.showCompletedTasks = projectFilter.showCompletedTasks;
+        this.tasksFilter = {
+          groupBy: projectFilter.groupBy,
+          orderBy: projectFilter.orderBy,
+          offset: 0,
+          limit: 0,
+          showCompletedTasks: projectFilter.showCompletedTasks,
+        };
+      } else {
+        this.tasksFilter = {
+          groupBy: '',
+          orderBy: '',
+          offset: 0,
+          limit: 0,
+          showCompletedTasks: false,
+        };
+      }
+      
       this.getStatusByProject(this.project.id);
       this.tasksList=[];
       this.getTasksByProject(this.project.id,'');
@@ -224,18 +249,80 @@ export default {
     }
   },
   created() {
-    this.$root.$on('refresh-tasks-list', () => {
-      this.getTasksByProject(this.project.id,'');
-      if ( this.taskViewTabName === 'gantt' ) {
-        return this.$tasksService.getTasksByProjectId(this.project.id).then(data => {
-          this.allProjectTasks = data && data || [];
-          this.$root.$emit('refresh-gantt', this.allProjectTasks);
+    this.$root.$on('task-added', task => {
+      this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
+        if (Array.isArray(data.tasks[0])) {
+          const tasksArrayIndex = data.tasks.findIndex(tasksArray => tasksArray.findIndex(t => t.id === task.id) > -1);
+
+          this.$set(this.tasksList, tasksArrayIndex, data.tasks[tasksArrayIndex]);
+        } else {
+          const taskIndex = data.tasks.findIndex(t => t.id === task.id);
+          this.tasksList.splice(taskIndex, 0, data.tasks[taskIndex]);
+        }
+      });
+    });
+
+    this.$root.$on('task-isCompleted-updated', task => {
+      this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
+        if (Array.isArray(data.tasks[0])) {
+
+          const showCompletedTaskFilter = {
+            query: this.tasksFilter.query,
+            groupBy: this.tasksFilter.groupBy,
+            orderBy: this.tasksFilter.orderBy,
+            offset: 0,
+            limit: 0,
+            showCompletedTasks: true,
+          };
+          let tasksArrayIndex = -1;
+
+          this.$tasksService.filterTasksList(showCompletedTaskFilter, '', '', '', this.project.id).then(showCompleteData => {
+            tasksArrayIndex = showCompleteData.tasks.findIndex(tasksArray => tasksArray.findIndex(t => t.id === task.id) > -1);
+            this.$set(this.tasksList, tasksArrayIndex, data.tasks[tasksArrayIndex]);
+          });
+
+        } else {
+          this.tasksList = data.tasks;
+
+        }
+      });
+    });
+
+    this.$root.$on('task-assignee-coworker-updated', task => {
+      this.updateModifiedTask(task);
+    });
+
+    this.$root.$on('task-priority-updated', value => {
+      if (this.tasksFilter.orderBy === 'priority') {
+        this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
+          if (Array.isArray(data.tasks[0])) {
+            const tasksArrayIndex = this.tasksList.findIndex(tasksArray => tasksArray.findIndex(t => t.id === value.taskId) > -1);
+            this.$set(this.tasksList, tasksArrayIndex, data.tasks[tasksArrayIndex]);
+          } else {
+            const taskOldIndex = this.tasksList.findIndex(t => t.id === value.taskId);
+            const taskNewIndex = data.tasks.findIndex(task => task.id === value.taskId);
+
+            this.tasksList.splice(taskOldIndex, 1);
+            this.tasksList.splice(taskNewIndex, 0, data.tasks[taskNewIndex]);
+          }
         });
       }
     });
+
+    this.$root.$on('task-due-date-updated', task => {
+      this.updateModifiedTask(task);
+    });
+    
     this.$root.$on('deleteTask', (event) => {
       if (event && event.detail) {
-        this.tasksList = this.tasksList.filter((t) => t.id !== event.detail);
+        const taskId = event.detail;
+        if (Array.isArray(this.tasksList[0])) {
+          const targetTasksArrayIndex = this.tasksList.findIndex(tasksArray => tasksArray.findIndex(t => t.id === taskId) > -1);
+          const updatedArray = this.tasksList[targetTasksArrayIndex].filter(t => t.id !== taskId);
+          this.$set(this.tasksList, targetTasksArrayIndex, updatedArray);
+        } else {
+          this.tasksList = this.tasksList.filter(t => t.id !== taskId);
+        }
       }
     });
   },
@@ -257,7 +344,7 @@ export default {
     getAllProjectTasks(projectId) {
       return this.$tasksService.getTasksByProjectId(projectId).then(data => {
         this.allProjectTasks = [];
-        this.allProjectTasks = data && data || [];
+        this.allProjectTasks = data ? data : [];
         this.$root.$emit('gantt-displayed', this.allProjectTasks);
       });
     },
@@ -271,50 +358,47 @@ export default {
         this.getTasksByProject(this.project.id,keyword);
       }
     },
-    getTasksByProject(ProjectId,query) {
-      const currentTab= this.taskViewTabName;
-      this.tasksList=[];
-      this.filterProjectActive=false;
-      this.groupName=null;
-      const projectFilter = JSON.parse(localStorage.getItem(`filterStorage${ProjectId}+${currentTab}`));
-      if (projectFilter){
-        if (projectFilter['projectId'] === ProjectId && projectFilter['tabView'] === currentTab) {
-          this.groupBy = projectFilter['groupBy'];
-          this.sortBy = projectFilter['sortBy'];
-          const tasksFilter = {
+    getTasksByProject(ProjectId, query) {
+      const currentTab = this.taskViewTabName;
+      this.tasksList = [];
+      this.filterProjectActive = false;
+      this.groupName = null;      
+      if (localStorage.getItem(`filterStorage${ProjectId}+${currentTab}`)) {
+        const projectFilter = JSON.parse(localStorage.getItem(`filterStorage${ProjectId}+${currentTab}`));
+        if (projectFilter.projectId && projectFilter.projectId === ProjectId && projectFilter.tabView && projectFilter.tabView === currentTab) {
+          this.tasksFilter = {
             query: query,
-            groupBy: this.groupBy,
-            orderBy: this.sortBy,
+            groupBy: projectFilter.groupBy,
+            orderBy: projectFilter.orderBy,
             offset: 0,
             limit: 0,
-            showCompleteTasks: false,
+            showCompletedTasks: projectFilter.showCompletedTasks,
           };
-          if (this.groupBy === 'completed') {
-            tasksFilter.showCompleteTasks = true;
-          }
-          return this.getFilter(tasksFilter, ProjectId);
+          return this.getFilter(this.tasksFilter, ProjectId);
         }
       } else {
-        this.getFilterProject(ProjectId,currentTab).then(() => {
-          const tasksFilter = {
+        this.getFilterProject(ProjectId, currentTab).then(() => {
+          this.tasksFilter = {
             query: query,
-            groupBy: this.groupBy,
-            orderBy: this.sortBy,
+            groupBy: '',
+            orderBy: '',
             offset: 0,
             limit: 0,
-            showCompleteTasks: false,
+            showCompletedTasks: false,
           };
-          if (this.groupBy==='completed'){
-            tasksFilter.showCompleteTasks=true;
+          
+          if (this.tasksFilter.groupBy === 'completed') {
+            this.tasksFilter.showCompletedTasks = true;
           }
           const jsonToSave = {
-            groupBy: this.groupBy,
-            sortBy: this.sortBy,
+            groupBy: this.tasksFilter.groupBy,
+            orderBy: this.tasksFilter.orderBy,
             projectId: ProjectId,
-            tabView: (this.taskViewTabName!==''? this.taskViewTabName : 'list'),
+            tabView: (this.taskViewTabName !== '' ? this.taskViewTabName : 'list'),
+            showCompletedTasks: this.showCompletedTasks,
           };
-          localStorage.setItem(`filterStorage${ProjectId}+${jsonToSave.tabView}`,JSON.stringify(jsonToSave));
-          return this.getFilter(tasksFilter,ProjectId);
+          localStorage.setItem(`filterStorage${ProjectId}+${jsonToSave.tabView}`, JSON.stringify(jsonToSave));
+          return this.getFilter(this.tasksFilter, ProjectId);
         });
       }
     },
@@ -322,37 +406,36 @@ export default {
       this.getTasksByProject(this.project.id,'');
       this.filterByStatus=false;
     },
-    filterTaskDashboard(e){
+    filterTaskDashboard(e) {
       this.loadingTasks = true;
-      this.taskFilter = e.tasks;
-      this.filterAsCompleted = e.showCompleteTasks;
-      this.taskFilter.showCompleteTasks=e.showCompleteTasks;
-      if (this.taskFilter.groupBy==='completed'){
-        this.taskFilter.showCompleteTasks=true;
+      this.tasksFilter = e.tasks;
+      this.showCompletedTasks = e.showCompletedTasks;
+      this.tasksFilter.showCompletedTasks = e.showCompletedTasks;
+      if (this.tasksFilter.groupBy === 'completed') {
+        this.tasksFilter.showCompletedTasks = true;
       }
-      if (this.taskFilter.groupBy==='none'){
-        this.filterByStatus=false;
+      if (this.tasksFilter.groupBy === 'none') {
+        this.filterByStatus = false;
       }
-      if (this.taskFilter.groupBy==='status'){
-        this.taskFilter.groupBy='';
-        this.filterProjectActive=false;
-        this.filterByStatus=true;
-        return this.$tasksService.filterTasksList(this.taskFilter,'','',e.filterLabels.labels,this.project.id).then(data => {
-          this.filterProjectActive=false;
-          this.filterByStatus=true;
+      if (this.tasksFilter.groupBy === 'status') {
+        this.tasksFilter.groupBy = '';
+        this.filterProjectActive = false;
+        this.filterByStatus = true;
+        return this.$tasksService.filterTasksList(this.tasksFilter, '', '', e.filterLabels.labels, this.project.id).then(data => {
+          this.filterProjectActive = false;
+          this.filterByStatus = true;
           this.tasksList = data && data.tasks || [];
 
         }).finally(() => this.loadingTasks = false);
       } else {
-        this.filterByStatus=false;
-        return this.$tasksService.filterTasksList(e.tasks,'','',e.filterLabels.labels,this.project.id).then(data => {
-          if (data.projectName){
-            this.filterProjectActive=true;
+        this.filterByStatus = false;
+        return this.$tasksService.filterTasksList(e.tasks, '', '', e.filterLabels.labels, this.project.id).then(data => {
+          if (data.projectName) {
+            this.filterProjectActive = true;
             this.tasksList = data && data.tasks || [];
-            this.groupName=data;
-          }
-          else {
-            this.filterProjectActive=false;
+            this.groupName = data;
+          } else {
+            this.filterProjectActive = false;
             this.tasksList = data && data.tasks || [];
           }
 
@@ -450,47 +533,42 @@ export default {
         this.$root.$emit('show-alert',{type: 'error',message: this.$t('alert.error')} );
       });
     },
-    getFilter(tasksFilter,ProjectId){
-      if (tasksFilter) {
-        this.taskFilter = tasksFilter;
-      }
-      if (tasksFilter.groupBy==='status') {
+    getFilter(tasksFilter, ProjectId) {
+      if (tasksFilter.groupBy === 'status') {
         tasksFilter.groupBy = '';
-        this.filterProjectActive=false;
-        this.filterByStatus=true;
-        this.$tasksService.filterTasksList(tasksFilter,'','','',ProjectId).then(data => {
-          this.filterProjectActive=false;
+        this.filterProjectActive = false;
+        this.filterByStatus = true;
+        this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', ProjectId).then(data => {
+          this.filterProjectActive = false;
           this.tasksList = data && data.tasks || [];
         }).finally(() => this.loadingTasks = false);
-      }  else {
-        this.$tasksService.filterTasksList(tasksFilter,'','','',ProjectId).then(data => {
-          this.filterByStatus=false;
-          if (data.projectName){
-            this.filterProjectActive=true;
+      } else {
+        this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', ProjectId).then(data => {
+          this.filterByStatus = false;
+          if (data.projectName) {
+            this.filterProjectActive = true;
             this.tasksList = data && data.tasks || [];
-            this.groupName=data;
-          }
-          else {
-            this.filterProjectActive=false;
+            this.groupName = data;
+          } else {
+            this.filterProjectActive = false;
             this.tasksList = data && data.tasks || [];
           }
 
         }).finally(() => this.loadingTasks = false);
       }
-
-
+      
     },
-    getFilterProject(ProjectId,currentTab){
-      return this.$projectService.getFilterSettings(ProjectId,currentTab).then((resp) =>{
-        if (resp && resp.value){
+    getFilterProject(ProjectId, currentTab) {
+      return this.$projectService.getFilterSettings(ProjectId, currentTab).then((resp) => {
+        if (resp && resp.value) {
           const StorageSaveFilter = resp.value;
           if (StorageSaveFilter.split('"')[10].split('}')[0].split(':')[1].split(',')[0] === ProjectId.toString()) {
-            this.groupBy = StorageSaveFilter.split('"')[3];
-            this.sortBy = StorageSaveFilter.split('"')[7];
+            this.tasksFilter.groupBy = StorageSaveFilter.split('"')[3].trim();
+            this.tasksFilter.orderBy = StorageSaveFilter.split('"')[7].trim();
           }
         } else {
-          this.groupBy = 'none';
-          this.sortBy = '';
+          this.tasksFilter.groupBy = 'none';
+          this.tasksFilter.orderBy = '';
         }
       });
     },
@@ -502,6 +580,33 @@ export default {
         title: ''};
       this.$root.$emit('open-task-drawer', defaultTask);
     },
+    updateModifiedTask(task) {
+      this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
+        if (Array.isArray(data.tasks[0])) {
+          if (data.tasks.length !== this.tasksList.length) {
+            this.getTasksByProject(this.project.id, '');
+            if (this.taskViewTabName === 'gantt') {
+              this.$tasksService.getTasksByProjectId(this.project.id).then(tasks => {
+                this.allProjectTasks = tasks ? tasks : [];
+                this.$root.$emit('refresh-gantt', this.allProjectTasks);
+              });
+            }
+          } else {
+            const tasksArrayOldIndex = this.tasksList.findIndex(tasksArray => tasksArray.findIndex(t => t.id === task.id) > -1);
+            const tasksArrayNewIndex = data.tasks.findIndex(tasksArray => tasksArray.findIndex(t => t.id === task.id) > -1);
+
+            this.$set(this.tasksList, tasksArrayOldIndex, data.tasks[tasksArrayOldIndex]);
+            this.$set(this.tasksList, tasksArrayNewIndex, data.tasks[tasksArrayNewIndex]);
+          }
+        } else {
+          const taskOldIndex = this.tasksList.findIndex(t => t.id === task.id);
+          const taskNewIndex = data.tasks.findIndex(t => t.id === task.id);
+
+          this.tasksList.splice(taskOldIndex, 1);
+          this.tasksList.splice(taskNewIndex, 0, data.tasks[taskNewIndex]);
+        }
+      });
+    }
   }
 };
 </script>

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewList.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewList.vue
@@ -14,9 +14,8 @@
                 :status="status"
                 :project="project"
                 :tasks-list="getTasksByStatus(tasksList,status.name)"
-                :show-completed-tasks="filterTaskCompleted"
+                :show-completed-tasks="showCompletedTasks"
                 :filter-by-status="filterByStatus"
-                @updateTaskCompleted="updateTaskCompleted"
                 @updateTaskStatus="updateTaskStatus" />
             </div>
           </div>
@@ -24,9 +23,8 @@
           <div v-else class="pt-0 px-3 projectTaskItem">
             <tasks-view-list-column
               :tasks-list="tasksList"
-              :show-completed-tasks="filterTaskCompleted"
+              :show-completed-tasks="showCompletedTasks"
               :filter-by-status="filterByStatus"
-              @updateTaskCompleted="updateTaskCompleted"
               @updateTaskStatus="updateTaskStatus" />
           </div>
         </div>
@@ -46,7 +44,7 @@ export default {
       type: Array,
       default: () => []
     },
-    filterTaskCompleted: {
+    showCompletedTasks: {
       type: Boolean,
       default: false
     },
@@ -81,11 +79,6 @@ export default {
         }
       });
       return tasksByStatus;
-    },
-    updateTaskCompleted(e){
-      if ( !this.filterTaskCompleted ) {
-        this.$root.$emit('update-task-completed', e);
-      }
     },
     updateTaskStatus(task,newStatus){
       const status = this.statusList.find(s => s.id.toString() === newStatus || s.name === newStatus);

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
@@ -14,15 +14,16 @@
           v-model="tasksList"
           :move="checkMove"
           :animation="200"
+          :key="draggableKey"
           class="draggable-palceholder"
           ghost-class="ghost-card"
           :options="{group:'status'}"
           @start="drag=true"
           @end="drag=false">
           <task-view-list-item
-            v-for="tasks in tasksList"
-            :key="tasks.task.id"
-            :task="tasks"
+            v-for="taskListItem in tasksList"
+            :key="taskListItem.task.id"
+            :task="taskListItem"
             :show-completed-tasks="showCompletedTasks"
             @update-task-completed="updateTaskCompleted" />
         </draggable>
@@ -62,6 +63,7 @@ export default {
       drag: false,
       task: null,
       newStatus: null,
+      draggableKey: 1,
     };
   },
   watch: {
@@ -73,8 +75,12 @@ export default {
     },
   },
   methods: {
-    updateTaskCompleted(e){
-      this.$emit('updateTaskCompleted', e);
+    updateTaskCompleted(task) {
+      if (!this.showCompletedTasks && task.completed) {
+        setTimeout(() => {
+          this.$root.$emit('task-isCompleted-updated', task);
+        }, 500);
+      }
     },
     checkMove(evt){
       if (evt){
@@ -84,6 +90,9 @@ export default {
         this.newStatus = evt.to.parentElement.id;
       }
 
+    },
+    reRenderTasks() {
+      this.draggableKey += 1;
     },
   }
 };

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
@@ -51,12 +51,13 @@
         </v-btn>
       </v-scale-transition>
     </v-toolbar>
-    <task-filter-drawer
+    <tasks-filter-drawer
       ref="filterTasksDrawer"
       :project="project.id"
       :query="keyword"
       :status-list="statusList"
       :task-view-tab-name="taskViewTabName"
+      :show-completed-tasks="showCompletedTasks"
       @filter-num-changed="filterNumChanged"
       @filter-task="filterTasks"
       @reset-filter-task="resetFilterTask" />
@@ -84,6 +85,10 @@ export default {
     taskGanttTabView: {
       type: String,
       default: ''
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false
     },
   },
   data () {
@@ -134,11 +139,14 @@ export default {
       this.searchonkeyChange=true;
       this.$emit('reset-filter-task-dashboard');
     },
-    filterTasks(e){
-      this.searchonkeyChange=false;
-      this.showCompleteTasks=e.showCompleteTasks;
-      this.keyword=e.tasks.query;
-      this.$emit('filter-task-dashboard', { tasks: e.tasks,filterLabels: e.filterLabels,showCompleteTasks: e.showCompleteTasks });
+    filterTasks(e) {
+      this.searchonkeyChange = false;
+      this.keyword = e.tasks.query;
+      this.$emit('filter-task-dashboard', {
+        tasks: e.tasks,
+        filterLabels: e.filterLabels,
+        showCompletedTasks: e.showCompletedTasks
+      });
     },
     resetFields(activeField){
       this.$refs.filterTasksDrawer.resetFields(activeField);

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -139,8 +139,6 @@ export default {
       isPersonnalTask: this.task.task.status === null,
       drawer: null,
       maxAvatarToShow: 1,
-      showCompleteTasks: false,
-      removeCompletedTask: false
     };
   },
   computed: {
@@ -159,15 +157,25 @@ export default {
     },
     displayCardBottomSection() {
       return this.taskDueDate || (this.task.labels && this.task.labels.length) || (this.assigneeAndCoworkerArray && this.assigneeAndCoworkerArray.length) || this.task.commentCount;
-    }
+    },
+    removeCompletedTask() {
+      return this.task.task.completed === true && !this.showCompletedTasks;
+    },
+  },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
   },
   created() {
-    this.$root.$on('update-completed-task',(value,id)=>{
-      if (this.task.id === id){
-        this.task.task.completed=value;
-        if (this.task.task.completed === true && !this.showCompletedTasks){
+    this.$root.$on('update-completed-task', (value, id) => {
+      if (this.task.id === id) {
+        this.task.task.completed = value;
+        if (this.task.task.completed === true && !this.showCompletedTasks) {
           this.$emit('update-task-completed', this.task.task);
-          this.removeCompletedTask = true;
         }
       }
     });
@@ -312,37 +320,27 @@ export default {
     updateCompleted() {
       const task = {
         id: this.task.task.id,
-        showCompleteTasks: this.showCompleted(),
+        isCompleted: !this.task.task.completed,
       };
-      if (typeof task.id !== 'undefined') {
-        return this.$tasksService.updateCompleted(task).then(task => {
-          if (task.completed){
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.completed')});
+      
+      if (task.id) {
+        return this.$tasksService.updateCompleted(task).then(updateTask => {
+          if (updateTask.completed) {
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.completed')});
           } else {
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.unCompleted')});
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.unCompleted')});
           }
-          this.$root.$emit('update-task-completed', task);
-          if ( task.completed === true && !this.showCompletedTasks) {
-            this.removeCompletedTask = true;
-          }
-        }).then(this.task.task.completed = task.showCompleteTasks)
-          .catch(e => {
-            console.error('Error updating task completed', e);
-            this.$root.$emit('show-alert', {
-              type: 'error',
-              message: this.$t('alert.error')
-            });
-            this.postProject = false;
+          this.$root.$emit('update-task-completed', updateTask);
+          this.task.task.completed = task.isCompleted;
+        }).catch(e => {
+          console.error('Error updating task completed', e);
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t('alert.error')
           });
+          this.postProject = false;
+        });
       }
-    },
-    showCompleted() {
-      if (this.getTaskCompleted() === 'uiIconValidate') {
-        this.showCompleteTasks = false;
-      } else {
-        this.showCompleteTasks = true;
-      }
-      return this.showCompleteTasks;
     },
     getTitleTaskClass() {
       if (this.task.task.completed === true) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksCardsList.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksCardsList.vue
@@ -14,7 +14,8 @@
               xl="3"
               class="pa-0 projectItem">
               <task-card
-                :task="task" />
+                :task="task"
+                :show-completed-tasks="showCompletedTasks" />
             </v-col>
           </v-row>
         </v-container>
@@ -28,7 +29,11 @@ export default {
     tasks: {
       type: Array,
       default: () =>[],
-    }
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false,
+    },
   },
 
 };

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -8,22 +8,22 @@
       :task-card-tab="'#tasks-cards'"
       :task-list-tab="'#tasks-list'"
       :keyword="keyword"
+      :show-completed-tasks="showCompletedTasks"
       @keyword-changed="keywordChanged"
       @filter-task-dashboard="filterTaskDashboard"
-      @filter-task-query="filterTaskquery"
+      @filter-task-query="filterTaskQuery"
       @primary-filter-task="getTasksByPrimary"
-      @reset-filter-task-dashboard="resetFiltertaskDashboard" />
+      @reset-filter-task-dashboard="resetFilterTaskDashboard" />
     <div
       v-if="(!tasks || !tasks.length) && !loadingTasks && !filterActive"
       class="noTasksProject">
       <div class="noTasksProjectIcon"><i class="uiIcon uiIconTask"></i></div>
       <div class="noTasksProjectLabel"><span>{{ $t('label.noTask') }}</span></div>
-      <!-- <div class="noTasksProjectLink"><a href="#">{{ $t('label.addTask') }}</a></div> -->
     </div>
     <div v-else>
-      <div v-if="filterActive && tasksFilter && tasksFilter.projectName" class="px-0 pt-8 pb-4">
+      <div v-if="filterActive && filterTaskQueryResult && filterTaskQueryResult.projectName" class="px-0 pt-8 pb-4">
         <div 
-          v-for="(project,i) in tasksFilter.projectName" 
+          v-for="(project,i) in filterTaskQueryResult.projectName" 
           :key="project.name" 
           class="pt-5">
           <div v-if=" project.value && project.value.displayName" class="d-flex align-center assigneeFilter">
@@ -50,7 +50,7 @@
               :title="project.value.displayName"
               :size="26"
               class="pe-2" />
-            <span class="amount-item">({{ tasksFilter.tasks[i].length }})</span>
+            <span class="amount-item">({{ filterTaskQueryResult.tasks[i].length }})</span>
             <hr
               role="separator"
               aria-orientation="horizontal"
@@ -77,7 +77,7 @@
               <img :src="defaultAvatar">
             </div>
             <span class="nameGroup">{{ $t(getGroupName(project.name)) }}</span>
-            <span class="amount-item">({{ tasksFilter.tasks[i].length }})</span>
+            <span class="amount-item">({{ filterTaskQueryResult.tasks[i].length }})</span>
             <hr
               role="separator"
               aria-orientation="horizontal"
@@ -85,10 +85,12 @@
           </div>
           <div :id="'taskView'+project.rank" class="view-task-group-sort">
             <tasks-cards-list
-              :tasks="tasksFilter.tasks[i]"
+              :tasks="filterTaskQueryResult.tasks[i]"
+              :show-completed-tasks="showCompletedTasks"
               class="d-md-none" />
             <tasks-list
-              :tasks="tasksFilter.tasks[i]"
+              :tasks="filterTaskQueryResult.tasks[i]"
+              :show-completed-tasks="showCompletedTasks"
               class="d-md-block d-none" />
           </div>
         </div>
@@ -96,11 +98,13 @@
       <div v-else>
         <div class="d-md-block d-none">
           <tasks-list
-            :tasks="tasks" />
+            :tasks="tasks"
+            :show-completed-tasks="showCompletedTasks" />
         </div>
         <div class="d-md-none">
           <tasks-cards-list
-            :tasks="tasks" />
+            :tasks="tasks"
+            :show-completed-tasks="showCompletedTasks" />
         </div>
       </div>
     </div>
@@ -121,7 +125,7 @@
 export default {
   data () {
     return {
-      primaryfilter: 'ALL',
+      primaryFilter: 'ALL',
       tasks: [],
       keyword: null,
       loadingTasks: false,
@@ -134,12 +138,23 @@ export default {
       startSearchAfterInMilliseconds: 600,
       endTypingKeywordTimeout: 50,
       startTypingKeywordTimeout: 0,
-      showCompleteTasks: false,
-      tasksFilter: null,
+      showCompletedTasks: false,
+      filterTaskQueryResult: null,
       filterActive: false,
       groupBy: null,
-      sortBy: null,
+      orderBy: null,
       labels: [],
+      taskQueryFilter: {
+        query: '',
+        assignee: '',
+        statusId: '',
+        dueDate: '',
+        priority: '',
+        projectId: -2,
+        showCompletedTasks: this.showCompletedTasks,
+        groupBy: '',
+        orderBy: '',
+      },
       filterTasks: {
         query: '',
         assignee: '',
@@ -153,7 +168,7 @@ export default {
         orderBy: '',
         offset: this.offset,
         limit: this.limitToFetch,
-        showCompleteTasks: this.showCompleteTasks
+        showCompletedTasks: this.showCompletedTasks
       },
       defaultAvatar: '/portal/rest/v1/social/users/default-image/avatar',
     };
@@ -169,27 +184,45 @@ export default {
     },
   },
   created() {
-    this.originalLimitToFetch = this.limitToFetch = this.limit;
-    this.$root.$on('refresh-tasks-list', () => {
-      this.searchTasks();
+    this.groupBy = localStorage.getItem('filterStorageNone+list') ?
+      JSON.parse(localStorage.getItem('filterStorageNone+list')).groupBy : false;
+
+    this.orderBy = localStorage.getItem('filterStorageNone+list') ?
+      JSON.parse(localStorage.getItem('filterStorageNone+list')).orderBy : false;
+
+    this.showCompletedTasks = localStorage.getItem('filterStorageNone+list') ?
+      JSON.parse(localStorage.getItem('filterStorageNone+list')).showCompletedTasks : false;
+    this.filterTasks.showCompletedTasks = this.showCompletedTasks;
+
+    this.$root.$on('task-added', () => {
+      this.updateTasksList();
     });
-    this.$root.$on('filter-task-groupBy',tasks =>{
-      this.tasksFilter = tasks;
-      this.filterActive=true;
+
+    this.$root.$on('task-assignee-coworker-updated', () => {
+      this.updateTasksList();
     });
-    this.$root.$on('deleteTask', (event) => {
-      if (event && event.detail) {
-        this.tasks = this.tasks.filter((t) => t.id !== event.detail);
-      }
+
+    this.$root.$on('task-priority-updated', () => {
+      this.updateTasksList();
     });
+
+    this.$root.$on('task-due-date-updated', () => {
+      this.updateTasksList();
+    });
+
+    this.$root.$on('deleteTask', () => {
+      this.updateTasksList();
+    });
+
     this.$root.$on('update-cart', (event) => {
-      if (event && !this.showCompleteTasks) {
+      if (event && !this.showCompletedTasks) {
         window.setTimeout(() => this.tasks = this.tasks.filter((t) => t.id !== event.id), 500);
       }
     });
+
     this.$root.$on('update-task-completed', (event) => {
-      if (event && !this.showCompleteTasks) {
-        window.setTimeout(() => this.searchTasks(), 500);
+      if (event && !this.showCompletedTasks) {
+        window.setTimeout(() => this.updateTasksList(), 500);
       }
     });
   },
@@ -200,83 +233,63 @@ export default {
         this.filterTasks.query=this.keyword;
         this.resetSearch();
         this.searchTasks();
-        return;
-    
-        /*  this.startTypingKeywordTimeout = Date.now();
-        if (!this.loadingTasks) {
-          this.loadingTasks = true;
-          this.waitForEndTyping();
-        } */
       }
     },
-    resetFiltertaskDashboard(){
-      //this.searchTasks();
+    resetFilterTaskDashboard(){
       this.groupBy='';
-      this.sortBy='';
+      this.orderBy='';
       this.filterActive=false;
       this.resetSearch();
-      this.getTasksByPrimary(this.primaryfilter);
+      this.getTasksByPrimary(this.primaryFilter);
     },
     filterTaskDashboard(e){
       this.tasks=e.tasks;
-      this.showCompleteTasks=e.showCompleteTasks;
+      this.showCompletedTasks = e.showCompletedTasks;
       this.filterActive=false;
     },
 
-    filterTaskquery(e,filterGroupSort,filterLabels){
-      this.showCompleteTasks = e.showCompleteTasks;
-      this.groupBy=filterGroupSort.groupBy;
-      this.sortBy=filterGroupSort.sortBy;
-      this.labels=filterLabels.labels;
-      if (this.primaryfilter==='ALL'){
-        this.tasksFilter=e;
+    filterTaskQuery(e, filterGroupSort, filterLabels) {
+      this.showCompletedTasks = e.showCompletedTasks;
+      this.groupBy = filterGroupSort.groupBy;
+      this.orderBy = filterGroupSort.orderBy;
+      this.labels = filterLabels.labels;
+      if (this.primaryFilter === 'ALL') {
+        this.taskQueryFilter = e;
         this.resetSearch();
-        this.searchTasks(this.tasksFilter);
+        this.searchTasks(this.taskQueryFilter);
       } else {
-        if ((this.primaryfilter === 'OVERDUE' || this.primaryfilter === 'TODAY' || this.primaryfilter === 'TOMORROW' || this.primaryfilter === 'UPCOMING')&&e.dueDate&&e.dueDate!==this.primaryfilter){
-          this.tasks=[];
-          this.filterActive=false;
-        } else if (this.primaryfilter === 'ASSIGNED' && e.assignee){
-          this.tasks=[];
-          this.filterActive=false;
+        if ((this.primaryFilter === 'OVERDUE' || this.primaryFilter === 'TODAY' || this.primaryFilter === 'TOMORROW' || this.primaryFilter === 'UPCOMING' ||
+          this.primaryFilter === 'ASSIGNED' && e.assignee) && e.dueDate && e.dueDate !== this.primaryFilter) {
+          this.tasks = [];
+          this.filterActive = false;
         } else {
-          if (!this.primaryfilter === 'ASSIGNED'){
-            this.filterTasks.assignee=e.assignee; 
+          if (this.primaryFilter !== 'ASSIGNED') {
+            this.filterTasks.assignee = e.assignee;
           }
-          if (!(this.primaryfilter === 'OVERDUE' || this.primaryfilter === 'TODAY' || this.primaryfilter === 'TOMORROW' || this.primaryfilter === 'UPCOMING')){
-            this.filterTasks.dueDate=e.dueDate; 
+          if (!(this.primaryFilter === 'OVERDUE' || this.primaryFilter === 'TODAY' || this.primaryFilter === 'TOMORROW' || this.primaryFilter === 'UPCOMING')) {
+            this.filterTasks.dueDate = e.dueDate;
           }
-          this.filterTasks.query=e.query;           
-          this.filterTasks.statusId=e.statusId; 
-          this.filterTasks.priority=e.priority; 
-          this.filterTasks.showCompleteTasks=e.showCompleteTasks; 
+          this.filterTasks.query = e.query;
+          this.filterTasks.statusId = e.statusId;
+          this.filterTasks.priority = e.priority;
+          this.filterTasks.showCompletedTasks = e.showCompletedTasks;
           this.resetSearch();
-          this.searchTasks(this.tasksFilter);
+          this.searchTasks();
         }
       }
-      /*    return this.$tasksService.filterTasksList(e,filterGroupSort.groupBy,filterGroupSort.sortBy,filterLabels.labels).then((tasks) => {
-          if (tasks.projectName){
-             this.tasksFilter = tasks;
-             this.filterActive=true;
-          }else {
-            //this.filterTaskDashboard(e)
-            this.tasks=tasks.tasks;
-            this.showCompleteTasks=e.showCompleteTasks;
-            this.filterActive=false;
-          }         
-        }) */
     },
-    searchTasks(tasks) {
-      if (!tasks){
-        tasks = this.filterTasks;
+    searchTasks(tasksFilter) {
+      if (!tasksFilter) {
+        tasksFilter = this.filterTasks;
       }
       this.loadingTasks = true;
-      if (tasks.assignee){
-        tasks.projectId=-3;
+      if (tasksFilter.assignee) {
+        tasksFilter.projectId = -3;
       }
-      return this.$tasksService.filterTasksList(tasks,this.groupBy,this.sortBy,this.labels).then(data => {
+      
+      return this.$tasksService.filterTasksList(tasksFilter,this.groupBy,this.orderBy,this.labels).then(data => {
         if (data.projectName){
-          this.tasksFilter = data;
+          this.filterTaskQueryResult = data;
           this.filterActive=true;
         } else {
           this.tasks = data && data.tasks || [];
@@ -294,10 +307,10 @@ export default {
           this.$root.$applicationLoaded();
         });
     },
-    getTasksByPrimary(primaryfilter) { 
-      this.primaryfilter=primaryfilter;         
-      if (primaryfilter && (primaryfilter === 'OVERDUE' || primaryfilter === 'TODAY' || primaryfilter === 'TOMORROW' || primaryfilter === 'UPCOMING')){
-        this.filterTasks.dueDate=primaryfilter;
+    getTasksByPrimary(primaryFilter) {
+      this.primaryFilter=primaryFilter;         
+      if (primaryFilter && (primaryFilter === 'OVERDUE' || primaryFilter === 'TODAY' || primaryFilter === 'TOMORROW' || primaryFilter === 'UPCOMING')){
+        this.filterTasks.dueDate=primaryFilter;
         this.filterTasks.assignee='';
         this.filterTasks.watcher='';
         this.filterTasks.coworker='';
@@ -309,7 +322,7 @@ export default {
         this.filterTasks.projectId=-2;
         this.resetSearch();
         this.searchTasks();
-      } else if (primaryfilter && (primaryfilter === 'ASSIGNED')){
+      } else if (primaryFilter && (primaryFilter === 'ASSIGNED')){
         this.filterTasks.dueDate='';
         this.filterTasks.assignee='ME';
         this.filterTasks.watcher='';
@@ -322,7 +335,7 @@ export default {
         this.filterTasks.projectId=-3;
         this.resetSearch();
         this.searchTasks();
-      } else if (primaryfilter && (primaryfilter === 'WATCHED')){
+      } else if (primaryFilter && (primaryFilter === 'WATCHED')){
         this.filterTasks.dueDate='';
         this.filterTasks.assignee='';
         this.filterTasks.watcher='ME';
@@ -335,7 +348,7 @@ export default {
         this.filterTasks.projectId=-3;
         this.resetSearch();
         this.searchTasks();
-      } else if (primaryfilter && (primaryfilter === 'COLLABORATED')){
+      } else if (primaryFilter && (primaryFilter === 'COLLABORATED')){
         this.filterTasks.dueDate='';
         this.filterTasks.assignee='';
         this.filterTasks.watcher='';
@@ -356,23 +369,22 @@ export default {
         this.filterTasks.statusId='';
         this.filterTasks.priority='';
         this.filterTasks.query='';
-        if (localStorage.getItem('filterStorageNone')!==null){
-          const localStorageSaveFilter = localStorage.getItem('filterStorageNone');
-          if (localStorageSaveFilter.split('"')[11] === 'None') {
-            this.groupBy = localStorageSaveFilter.split('"')[3];
-            this.sortBy = localStorageSaveFilter.split('"')[7];
-          }
+        if (localStorage.getItem('filterStorageNone+list')) {
+          const localStorageSavedFilter = JSON.parse(localStorage.getItem('filterStorageNone+list'));
+          this.groupBy = localStorageSavedFilter.groupBy;
+          this.orderBy = localStorageSavedFilter.orderBy;
         } else {
           this.getFilterProject().then(() => {
             const jsonToSave = {
               groupBy: this.groupBy,
-              sortBy: this.sortBy,
+              orderBy: this.orderBy,
               projectId: 'None',
-              tabView: 'list'
+              tabView: 'list',
+              showCompletedTasks: false,
             };
-            localStorage.setItem('filterStorageNone+list',JSON.stringify(jsonToSave));
+            localStorage.setItem('filterStorageNone+list', JSON.stringify(jsonToSave));
             this.filterTasks.projectId=-2;
-            this.searchTasks(this.filterTasks);
+            this.searchTasks();
           });
         }
         this.filterTasks.projectId=-2;
@@ -426,10 +438,10 @@ export default {
       return name;
     },
     showDetailsTask(id){
-      const uiIconMiniArrowDown = document.querySelector(`#${`uiIconMiniArrowDown${id}`}`);
-      const uiIconMiniArrowRight = document.querySelector(`#${`uiIconMiniArrowRight${id}`}`);
+      const uiIconMiniArrowDown = document.querySelector(`#uiIconMiniArrowDown${id}`);
+      const uiIconMiniArrowRight = document.querySelector(`#uiIconMiniArrowRight${id}`);
 
-      const detailsTask = document.querySelector(`#${`taskView${id}`}`);
+      const detailsTask = document.querySelector(`#taskView${id}`);
       if (detailsTask.style.display !== 'none') {
         detailsTask.style.display = 'none';
         uiIconMiniArrowDown.style.display = 'none';
@@ -445,11 +457,22 @@ export default {
           const StorageSaveFilter = resp.value;
           if (StorageSaveFilter.split('"')[11] === 'None') {
             this.groupBy = StorageSaveFilter.split('"')[3];
-            this.sortBy = StorageSaveFilter.split('"')[7];
+            this.orderBy = StorageSaveFilter.split('"')[7];
           }
         } else {
           this.groupBy = 'none';
-          this.sortBy = '';
+          this.orderBy = '';
+        }
+      });
+    },
+    updateTasksList() {
+      const filterTasks = this.filterActive ? this.taskQueryFilter : this.filterTasks;
+      this.$tasksService.filterTasksList(filterTasks, this.groupBy, this.orderBy, this.labels).then(data => {
+
+        if (this.filterActive) {
+          this.filterTaskQueryResult = data;
+        } else {
+          this.tasks = data.tasks;
         }
       });
     },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -28,7 +28,7 @@
                     v-model="groupBy" />
                   <tasks-sort-by-drawer
                     ref="filterSortTasksDrawer"
-                    v-model="sortBy" />
+                    v-model="orderBy" />
                 </v-card>
               </v-tab-item>
 
@@ -41,7 +41,7 @@
                     @scale-changed="changeScale" />
                   <tasks-sort-by-project-drawer
                     ref="filterSortTasksDrawer"
-                    v-model="sortBy" />
+                    v-model="orderBy" />
                 </v-card>
               </v-tab-item>
 
@@ -127,7 +127,7 @@
                         }}:</label>
                         <label class="switch">
                           <input
-                            v-model="showCompleteTasks"
+                            v-model="showCompletedTasks"
                             type="checkbox">
                           <div class="slider round"><span class="absolute-yes">{{ $t(`filter.task.showCompleted.yes`,"YES") }}</span></div>
                           <span class="absolute-no">{{ $t(`filter.task.showCompleted.no`) }}</span>
@@ -195,7 +195,7 @@ export default {
       type: String,
       default: ''
     },
-    sortBy: {
+    orderBy: {
       type: String,
       default: ''
     },
@@ -214,7 +214,11 @@ export default {
     statusList: {
       type: Array,
       default: () =>[],
-    }
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false,
+    },
   },
   data () {
     return {
@@ -231,7 +235,6 @@ export default {
       priority: [
         {name: ''},{name: 'NONE'},{name: 'LOW'},{name: 'NORMAL'},{name: 'HIGH'}
       ],
-      showCompleteTasks: false,
       labels: [],
     };
   },
@@ -264,34 +267,29 @@ export default {
     open() {
       const urlPath = document.location.pathname;
       this.getTabView();
-      if (urlPath.includes('projectDetail')){
-        let projectId = urlPath.split('projectDetail/')[1].split(/[^0-9]/)[0];
-        projectId = projectId && Number(projectId) || 0;
+      const projectId = urlPath.includes('projectDetail') && urlPath.split('projectDetail/')[1].split(/[^0-9]/)[0] ?
+        Number(urlPath.split('projectDetail/')[1].split(/[^0-9]/)[0]) : 0;
+      if (projectId > 0) {
         window.setTimeout(() => {
           document.dispatchEvent(new CustomEvent('loadFilterProjectLabels', {
             detail: projectId
           }));
-        },
-        200);
-        if (localStorage.getItem(`filterStorage${projectId}+${this.taskViewTabName}`) !== null) {
-          const localStorageSaveFilter = localStorage.getItem(`filterStorage${projectId}+${this.taskViewTabName}`);
-          if (localStorageSaveFilter.split('"')[10].split('}')[0].split(':')[1].split(',')[0] === projectId.toString()) {
-            this.groupBy = localStorageSaveFilter.split('"')[3];
-            this.sortBy = localStorageSaveFilter.split('"')[7];
-          }
-        }
+        }, 200);
+
       }
-      else if (urlPath.includes('myTasks')){
-        if (localStorage.getItem('filterStorageNone+list') !== null) {
-          const localStorageSaveFilter = localStorage.getItem('filterStorageNone+list');
-          if (localStorageSaveFilter.split('"')[11] === 'None') {
-            this.groupBy = localStorageSaveFilter.split('"')[3];
-            this.sortBy = localStorageSaveFilter.split('"')[7];
-          }
-        }
-      }
-      this.$root.$emit('reset-filter-task-group-sort',this.groupBy);
-      this.$root.$emit('reset-filter-task-sort',this.sortBy);
+      const filterStorageProperty = projectId > 0 ? `filterStorage${projectId}+${this.taskViewTabName}` : 'filterStorageNone+list';
+
+      const localStorageSaveFilter = localStorage.getItem(filterStorageProperty) ?
+        JSON.parse(localStorage.getItem(filterStorageProperty)) : null;
+
+      this.groupBy = projectId > 0 && localStorageSaveFilter && localStorageSaveFilter.projectId === projectId && localStorageSaveFilter.groupBy ||
+      localStorageSaveFilter && localStorageSaveFilter.projectId === 'None' && localStorageSaveFilter.groupBy ? localStorageSaveFilter.groupBy : '';
+
+      this.orderBy = projectId > 0 && localStorageSaveFilter && localStorageSaveFilter.projectId === projectId && localStorageSaveFilter.orderBy ||
+      localStorageSaveFilter && localStorageSaveFilter.projectId === 'None' && localStorageSaveFilter.orderBy ? localStorageSaveFilter.orderBy : '';
+      
+      this.$root.$emit('reset-filter-task-group-sort', this.groupBy);
+      this.$root.$emit('reset-filter-task-sort', this.orderBy);
       this.$refs.filterTasksDrawer.open();
     },
     cancel() {
@@ -306,36 +304,35 @@ export default {
       } else {
         this.groupBy='none';
       }
-      this.sortBy='';
+      this.orderBy='';
       this.labels='';
-      this.showCompleteTasks=false;
+      this.showCompletedTasks=false;
       this.getFilterNumber();
       this.$root.$emit('reset-filter-task-group-sort',this.groupBy);
     },
     reset() {
-      this.query=this.task.query;
-      this.assignee=this.task.assignee;
-      this.dueDateSelected='';
-      this.prioritySelected='';
-      this.statusSelected='';
-      if (this.taskViewTabName === 'list'){
-        this.groupBy='status';
+      this.query = this.task.query;
+      this.assignee = this.task.assignee;
+      this.dueDateSelected = '';
+      this.prioritySelected = '';
+      this.statusSelected = '';
+      if (this.taskViewTabName === 'list') {
+        this.groupBy = 'status';
       } else {
-        this.groupBy='';
+        this.groupBy = '';
       }
-      this.sortBy='';
-      this.labels='';
-      this.showCompleteTasks=false;
+      this.orderBy = '';
+      this.labels = '';
+      this.showCompletedTasks = false;
       this.getFilterNumber();
       const jsonToSave = {
         groupBy: this.groupBy,
-        sortBy: this.sortBy,
+        orderBy: this.orderBy,
         projectId: this.project || 'None',
-        tabView: this.taskViewTabName!==''? this.taskViewTabName : 'list',
+        tabView: this.taskViewTabName !== '' ? this.taskViewTabName : 'list',
       };
-      this.saveValueFilterInStorage(JSON.parse(JSON.stringify(jsonToSave)));
-      localStorage.setItem(`filterStorage${jsonToSave.projectId}+${jsonToSave.tabView}`,JSON.stringify(jsonToSave));
-      this.$root.$emit('reset-filter-task-group-sort',this.groupBy);
+      this.saveValueFilterInStorage(jsonToSave);      
+      this.$root.$emit('reset-filter-task-group-sort', this.groupBy);
       this.$emit('reset-filter-task');
     },
     resetFields(source) {
@@ -345,14 +342,14 @@ export default {
       this.prioritySelected='';
       this.statusSelected='';
       this.groupBy='';
-      this.sortBy='';
+      this.orderBy='';
       this.labels='';
-      this.showCompleteTasks=false;
+      this.showCompletedTasks=false;
       this.$root.$emit('reset-filter-task-group-sort',this.groupBy);
       this.getFilterNumber(source);
     },
-    filterTasks(){
-      if ( this.taskViewTabName === 'gantt' ) {
+    filterTasks() {
+      if (this.taskViewTabName === 'gantt') {
         this.cancel();
       } else {
         const tasks = {
@@ -361,41 +358,41 @@ export default {
           statusId: this.statusSelected,
           dueDate: this.dueDateSelected,
           priority: this.prioritySelected,
-          showCompleteTasks: this.showCompleteTasks,
+          showCompletedTasks: this.showCompletedTasks,
           groupBy: this.groupBy,
-          orderBy: this.sortBy,
+          orderBy: this.orderBy,
         };
         const filterGroupSort = {
           groupBy: this.groupBy,
-          sortBy: this.sortBy,
+          orderBy: this.orderBy,
         };
         const filterLabels = {
           labels: [],
         };
-        if (this.labels){
+        if (this.labels) {
           this.labels.forEach(user => {
             filterLabels.labels.push(user.id);
           });
         }
-        if (this.assignee){
+        if (this.assignee) {
           tasks.assignee = this.assignee.remoteId;
         }
         const jsonToSave = {
           groupBy: this.groupBy,
-          sortBy: this.sortBy,
+          orderBy: this.orderBy,
           projectId: this.project || 'None',
-          tabView: (this.taskViewTabName!==''? this.taskViewTabName : 'list'),
+          tabView: (this.taskViewTabName !== '' ? this.taskViewTabName : 'list'),
         };
-        this.saveValueFilterInStorage(JSON.parse(JSON.stringify(jsonToSave)));
-        if (this.project){
-          this.$emit('filter-task',{ tasks,filterLabels,showCompleteTasks: this.showCompleteTasks });
+        this.saveValueFilterInStorage(jsonToSave);
+        if (this.project) {
+          this.$emit('filter-task', {tasks, filterLabels, showCompletedTasks: this.showCompletedTasks});
           this.getFilterNumber();
-          if (this.$refs.filterTasksDrawer){
+          if (this.$refs.filterTasksDrawer) {
             this.$refs.filterTasksDrawer.close();
           }
         } else {
-          this.$emit('filter-task-query', tasks,filterGroupSort,filterLabels);
-       
+          this.$emit('filter-task-query', tasks, filterGroupSort, filterLabels);
+
           this.getFilterNumber();
           this.$refs.filterTasksDrawer.close();
         }
@@ -421,15 +418,20 @@ export default {
       if (this.labels&&this.labels.length>0){
         filtersnumber++;
       }
-      if (this.showCompleteTasks){
+      if (this.showCompletedTasks){
         filtersnumber++;
       }
       this.$emit('filter-num-changed',filtersnumber,source);
     },
-    saveValueFilterInStorage(value){
+    saveValueFilterInStorage(value) {
       this.$projectService.saveFilterSettings(value).then((response) => {
-        if (response){
-          localStorage.setItem(`filterStorage${value.projectId}+${value.tabView}`,JSON.stringify(value));
+        if (response) {
+          value.showCompletedTasks = this.showCompletedTasks;
+          if (this.project) {
+            localStorage.setItem(`filterStorage${value.projectId}+${value.tabView}`, JSON.stringify(value));
+          } else {
+            localStorage.setItem('filterStorageNone+list', JSON.stringify(value));
+          }
         }
       });
     },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksList.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksList.vue
@@ -5,7 +5,8 @@
       :key="task.id"
       class="tasksListItem">
       <tasks-list-item
-        :task="task" />
+        :task="task"
+        :show-completed-tasks="showCompletedTasks" />
     </div>
   </v-app>
 </template>
@@ -15,7 +16,11 @@ export default {
     tasks: {
       type: Array,
       default: () => [],
-    }
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false,
+    },    
   },
 };
 

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="getTaskPriorityColor(task.task.priority)"
+    :class="[getTaskPriorityColor(task.task.priority), removeCompletedTask && 'completedTask' || '']"
     class="taskListItemView  px-4 py-3 d-flex align-center">
     <div class="taskCheckBox">
       <v-switch
@@ -154,7 +154,11 @@ export default {
     task: {
       type: Object,
       default: null
-    }
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false
+    },
   },
   data () {
     return {
@@ -170,7 +174,6 @@ export default {
       labelList: '',
       isSpaceProject: this.task.space !== null,
       maxAvatarToShow: 1,
-      showCompleteTasks: false
     };
   },
   computed: {
@@ -186,7 +189,18 @@ export default {
     },
     showMoreAvatarsNumber() {
       return this.assigneeAndCoworkerArray.length - this.maxAvatarToShow;
+    },
+    removeCompletedTask() {
+      return this.task.task.completed === true && !this.showCompletedTasks;
     }
+  },
+  watch: {
+    'task.assignee'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
+    'task.coworker'() {
+      this.getTaskAssigneeAndCoworkers();
+    },
   },
   created() {
     this.$root.$on('update-completed-task',(value,id)=>{
@@ -301,31 +315,29 @@ export default {
     },
       
     updateCompleted() {
-
       const task = {
         id: this.task.task.id,
-        showCompleteTasks: this.showCompleted(),
+        isCompleted: !this.task.task.completed,
       };
-
-
-      if (typeof task.id !== 'undefined') {
-        return this.$tasksService.updateCompleted(task).then(task => {
-          if (task.completed){
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.completed')});   
+      
+      if (task.id) {
+        return this.$tasksService.updateCompleted(task).then(updatedTask => {
+          if (updatedTask.completed) {
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.completed')});
           } else {
-            this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.unCompleted')});
+            this.$root.$emit('show-alert', {type: 'success', message: this.$t('alert.success.task.unCompleted')});
           }
-          this.$root.$emit('update-cart', task);
-          this.$root.$emit('update-task-completed', task);
-        }).then(this.task.task.completed = task.showCompleteTasks)
-          .catch(e => {
-            console.error('Error updating project', e);
-            this.$root.$emit('show-alert', {
-              type: 'error',
-              message: this.$t('alert.error')
-            });
-            this.postProject = false;
+          this.$root.$emit('update-cart', updatedTask);
+          this.$root.$emit('update-task-completed', updatedTask);
+          this.task.task.completed = updatedTask.completed;
+        }).catch(e => {
+          console.error('Error updating project', e);
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t('alert.error')
           });
+          this.postProject = false;
+        });
       }
 
 
@@ -353,14 +365,6 @@ export default {
       else {
         return 'message.markAsCompleted';
       }
-    },
-    showCompleted(){
-      if (this.getTaskCompleted()==='uiIconValidate'){
-        this.showCompleteTasks=false;
-      } else {
-        this.showCompleteTasks=true;
-      }
-      return this.showCompleteTasks;
     },
     getNameProject(){
       if (this.task.task.status){

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListToolbar.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListToolbar.vue
@@ -69,9 +69,10 @@
         </v-btn>
       </v-scale-transition>
     </v-toolbar>
-    <task-filter-drawer
+    <tasks-filter-drawer
       ref="filterTasksDrawer"
       :query="keyword"
+      :show-completed-tasks="showCompletedTasks"
       @filter-num-changed="filterNumChanged"
       @filter-task="filterTasks"
       @reset-filter-task="resetFilterTask"
@@ -88,6 +89,10 @@ export default {
     taskListTab: {
       type: String,
       default: ''
+    },
+    showCompletedTasks: {
+      type: Boolean,
+      default: false
     },
   },
   data () {
@@ -117,7 +122,8 @@ export default {
       this.awaitingSearch = true;  
       this.searchOnKeyChange= true;
     },
-  },created() {
+  },
+  created() {
     this.primaryFilterSelected = localStorage.getItem('primary-filter-tasks');
     localStorage.setItem('primary-filter-tasks', 'ALL');
   },
@@ -131,16 +137,14 @@ export default {
     resetFilterTask(){
       this.$emit('reset-filter-task-dashboard');
     },
-    filterTaskquery(e,filterGroupSort,filterLabels){
-      this.searchOnKeyChange=false;
-      this.showCompleteTasks=e.showCompleteTasks;
-      this.keyword=e.query;
-      this.$emit('filter-task-query',e,filterGroupSort,filterLabels);
+    filterTaskquery(e, filterGroupSort, filterLabels) {
+      this.searchOnKeyChange = false;
+      this.keyword = e.query;
+      this.$emit('filter-task-query', e, filterGroupSort, filterLabels);
     },
-    filterTasks(e){
-      this.tasks=e.tasks.tasks;
-      this.showCompleteTasks=e.showCompleteTasks;
-      this.$emit('filter-task-dashboard', { tasks: this.tasks,showCompleteTasks: this.showCompleteTasks });
+    filterTasks(e) {
+      this.tasks = e.tasks.tasks;
+      this.$emit('filter-task-dashboard', {tasks: this.tasks, showCompletedTasks: this.showCompletedTasks});
     },
     openDrawer() {
       this.$refs.filterTasksDrawer.open();

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksSortByDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksSortByDrawer.vue
@@ -10,7 +10,7 @@
       </v-label>
     </form>
     <v-radio-group
-      v-model="sortBy"
+      v-model="orderBy"
       mandatory>
       <v-radio
         :label="$t('label.task.status')"
@@ -40,20 +40,20 @@ export default {
   },
   data() {
     return {
-      sortBy: this.value,
+      orderBy: this.value,
     };
   },
   watch: {
-    sortBy(val) {
+    orderBy(val) {
       this.$emit('input', val);
     },
   },
   created() {
     this.$root.$on('reset-filter-task-group-sort', () =>{
-      this.sortBy = '';
+      this.orderBy = '';
     });
-    this.$root.$on('reset-filter-task-sort',sortBy =>{
-      this.sortBy = sortBy;
+    this.$root.$on('reset-filter-task-sort',orderBy =>{
+      this.orderBy = orderBy;
     });
   }
 };

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksSortByProjectDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksSortByProjectDrawer.vue
@@ -10,7 +10,7 @@
       </v-label>
     </form>
     <v-radio-group
-      v-model="sortBy"
+      v-model="orderBy"
       mandatory>
       <v-radio
         :label="$t('label.task.dueDate')"
@@ -37,20 +37,20 @@ export default {
   },
   data() {
     return {
-      sortBy: this.value,
+      orderBy: this.value,
     };
   },
   watch: {
-    sortBy(val) {
+    orderBy(val) {
       this.$emit('input', val);
     },
   },
   created() {
     this.$root.$on('reset-filter-task-group-sort', () =>{
-      this.sortBy = '';
+      this.orderBy = '';
     });
-    this.$root.$on('reset-filter-task-sort',sortBy =>{
-      this.sortBy = sortBy;
+    this.$root.$on('reset-filter-task-sort',orderBy =>{
+      this.orderBy = orderBy;
     });
   }
 };

--- a/task-management/src/main/webapp/vue-app/tasks-management/initComponents.js
+++ b/task-management/src/main/webapp/vue-app/tasks-management/initComponents.js
@@ -65,7 +65,7 @@ const components = {
   'tasks-list-item': TasksListItem,
   'tasks-cards-list': TasksCardsList,
   'task-card': TaskCard,
-  'task-filter-drawer': TasksFilterDrawer,
+  'tasks-filter-drawer': TasksFilterDrawer,
   'tasks-assignee-coworker-drawer': TasksAssigneeAndCoworkerDrawer,
   'tasks-group-drawer': TasksGroupDrawer,
   'tasks-sort-by-drawer': TasksSortByDrawer,

--- a/task-management/src/main/webapp/vue-app/tasks/components/TasksApp.vue
+++ b/task-management/src/main/webapp/vue-app/tasks/components/TasksApp.vue
@@ -227,11 +227,7 @@ export default {
     this.$root.$on('task-updated',task => {
       this.task=task;
     });
-
-    this.$root.$on('refresh-tasks-list', task => {
-      this.retrieveTask(task);
-      this.task=task;
-    });
+    
     this.$root.$on('update-task-widget-list', task => {
       this.task=task;
       this.getMyOverDueTasks();
@@ -260,7 +256,7 @@ export default {
         dueCategory: 'overDue',
         offset: 0,
         limit: 0,
-        showCompleteTasks: false,
+        showCompletedTasks: false,
       };
       return filterTasksList(task,'','priority','','-2').then(
         (data) => {
@@ -279,7 +275,7 @@ export default {
         dueCategory: 'today',
         offset: 0,
         limit: 0,
-        showCompleteTasks: false,
+        showCompletedTasks: false,
       };
       return filterTasksList(task,'','priority','','-2').then(
         (data) => {
@@ -298,7 +294,7 @@ export default {
         dueCategory: 'tomorrow',
         offset: 0,
         limit: 0,
-        showCompleteTasks: false,
+        showCompletedTasks: false,
       };
       return filterTasksList(task,'','priority','','-2').then(
         (data) => {
@@ -316,7 +312,7 @@ export default {
       const task = {
         dueCategory: 'upcoming',
         offset: 0,
-        showCompleteTasks: false,
+        showCompletedTasks: false,
       };
       return filterTasksList(task,'','priority','','-2').then(
         (data) => {


### PR DESCRIPTION
**Problem:** When (adding a new task, updating a task status, marking a task as completed or updating task assignment) the UI is reloaded completely.
**Fixes:** To avoid this behavior i made sure to update only the needed array in the tasksList's data.
Make sure to update Task's card when the assignee or coworker are updated in list view:
These changes adds a watch property on the attributes task.assignee and task.coworker to trigger any updates.
Fix process of handling task completed filter updates and make sure to keep track of task filters besides the instant refresh of updated task's states avoiding full page reload:
These changes make sure that the property is stored in the browser storage and that it is unique and shared between templates instantly, and that the whole object of task filter is shared between templates in the same structure to avoid ambiguous variable naming.
The events listeners (this.$on()) of tasks updated state where centralized in the two main components (TasksViewDashboard.vue and TasksDashboard.vue). to avoid incoherent and unneeded events.
Also this fix make sure that the Task List board (which is accessed from the application center) updates are instantly too without the feel of page reload.
Some code refactor is included also some console log errors are handled.
Fix initialization of taskFilter property:
These changes make sure to initialize properly the property taskFilter.