### PR TITLE
Task-49547: New task - color of the layout description option are toobright

### DIFF
--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -243,7 +243,7 @@
           height: 30px;
         }
         .cke_bottom .cke_button_icon {
-          filter: opacity(0.2);
+          filter: opacity(0.4);
         }
         .projectDescription {
           .tooManyChars {
@@ -2734,7 +2734,7 @@
       height: 30px!important;
     }
     .cke_bottom .cke_button_icon {
-      filter: opacity(0.2);
+      filter: opacity(0.4);
     }
     .uiIconMessageLength {
       font-size: 14px;
@@ -2997,7 +2997,7 @@
         border-left: none ~'!important; /** orientation=rt */ ';
       }
       .cke_bottom .cke_button_icon {
-        filter: opacity(0.2);
+        filter: opacity(0.4);
       }
       .tooManyChars {
         color: #bc4343!important;


### PR DESCRIPTION
Prior this fix, the options list in editor of the task description is too grey bright and seems like deactivated.