### PR TITLE
Task-46419: Fix description loss

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -87,6 +87,7 @@ export default {
           document.getElementById('taskDescriptionId').classList.add('taskDescription');
         }
       }
+      this.saveDescription(this.inputVal);
     },
     reset() {
       CKEDITOR.instances['descriptionContent'].destroy(true);


### PR DESCRIPTION
Problem: the task's description is lost after refreshing the page.
How it was solved: by calling the saveDescription method after editing the task.