### PR TITLE
MAINT-49286: Fix updating cloned task description

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -119,6 +119,7 @@ export default {
                 type: 'success',
                 message: this.$t('alert.success.task.description')
               });
+              this.$root.$emit('task-description-updated', this.task);
             }).catch(e => {
               console.error('Error when updating task\'s descriprion', e);
               this.$root.$emit('show-alert',{type: 'error',message: this.$t('alert.error')} );

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -288,6 +288,10 @@ export default {
       });
     });
 
+    this.$root.$on('task-description-updated', task => {
+      this.updateModifiedTask(task);
+    });
+
     this.$root.$on('task-assignee-coworker-updated', task => {
       this.updateModifiedTask(task);
     });


### PR DESCRIPTION
**ISSUE**: The description of the cached tasks weren't updated when editing a description which caused an issue in the cloned tasks
**FIX**: Emit a custom event when saving a new description value to allow updating the target task description in the cache.