### PR TITLE
Task-48966: Wrong dates of new comments on the first drawer (#714)

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentItem.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentItem.vue
@@ -43,7 +43,7 @@
           text
           small
           color="primary"
-          @click="$emit('openCommentEditor',comment.comment.id)">
+          @click="replyComment">
           {{ $t('comment.message.Reply') }}
         </v-btn>
       </div>
@@ -72,9 +72,18 @@ export default {
         return {};
       }
     },
+    replyLastComment: {
+      type: Boolean,
+      default: false
+    }
+    ,
     showOnly: {
       type: Boolean,
       default: true
+    },
+    lastCommentId: {
+      type: String,
+      default: ''
     },
     comments: {
       type: Object,
@@ -98,7 +107,7 @@ export default {
   },
   computed: {
     showDeleteButtom() {
-      return this.hover && eXo.env.portal.userName === this.comment.author.username;
+      return this.hover && !this.replyLastComment && eXo.env.portal.userName === this.comment.author.username;
     },
     relativeTime() {
       return this.getRelativeTime(this.comment.comment.createdTime.time);
@@ -133,6 +142,16 @@ export default {
         return this.displayCommentDate(this.comment.comment.createdTime.time);
       }
     },
+    replyComment()
+    {
+      if (this.replyLastComment)
+      {
+        this.$root.$emit('displayTaskComment', this.lastCommentId);
+      }
+      else {
+        this.$emit('openCommentEditor',this.comment.comment.id);
+      }
+    }
   },
 };
 </script>

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskLastComment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskLastComment.vue
@@ -34,38 +34,14 @@
     <div v-if="comment.subComments && comment.subComments.length" class="py-0 TaskSubComments">
       <div
         v-for="(item, i) in comment.subComments"
-        :key="i">
-        <div class="TaskSubCommentItem ps-10 pe-0 pb-2">
-          <div class="commentItem">
-            <div class="commentHeader d-flex">
-              <exo-user-avatar
-                :username="item.author.username"
-                :avatar-url="item.author.avatar"
-                :title="item.author.displayName"
-                :size="30"
-                :url="item.author.url" />
-              <div class="commentContent ps-3 d-flex align-center">
-                <a
-                  class="primary-color--text font-weight-bold subtitle-2 pe-2">{{ item.author.displayName }} <span v-if="lastSubComment.author.external" class="externalTagClass">{{ ` (${$t('label.external')})` }}</span></a>
-                <span :title="displayCommentDate" class="dateTime caption font-italic d-block">{{ relativeTime }}</span>
-              </div>
-            </div>
-            <div class="commentBody ms-10 mt-1">
-              <div
-                class="taskContentComment"
-                v-html="item.formattedComment"></div>
-              <v-btn
-                id="reply_btn"
-                depressed
-                text
-                small
-                color="primary"
-                @click="openCommentDrawer">
-                {{ $t('comment.message.Reply') }}
-              </v-btn>
-            </div>
-          </div>
-        </div>
+        :key="i"
+        class="TaskSubCommentItem pe-0 pb-2">
+        <task-comment-item 
+          :comment="item"
+          :comments="comment.subComments"
+          :avatar-size="30"
+          :reply-last-comment="true"
+          :last-comment-id="comment.comment.id" /> 
       </div>
     </div>
   </div>


### PR DESCRIPTION
Problem: On the first drawer, all subcomments take the date of the first comment (date is not updated even after refreshing).
Fix: Dates of subcomments should be updated on the first drawer as displayed on the second drawer. 