### PR TITLE
TASK-46723: Fix comment's date title

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentItem.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskCommentItem.vue
@@ -17,7 +17,7 @@
         <div class="commentContent ps-3 d-flex align-center">
           <a
             class="primary-color--text font-weight-bold subtitle-2 pe-2">{{ comment.author.displayName }} <span v-if="comment.author.external" class="externalTagClass">{{ ` (${$t('label.external')})` }}</span></a>
-          <span :title="displayCommentDate" class="dateTime caption font-italic d-block">{{ relativeTime }}</span>
+          <span :title="displayCommentDate(comment.comment.createdTime.time)" class="dateTime caption font-italic d-block">{{ relativeTime }}</span>
         </div>
         <div class="removeCommentBtn">
           <v-btn

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskLastComment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskLastComment.vue
@@ -14,7 +14,7 @@
       <div class="commentContent ps-3 d-flex align-center">
         <a
           class="primary-color--text font-weight-bold subtitle-2 pe-2">{{ comment.author.displayName }} <span v-if="comment.author.external" class="externalTagClass">{{ ` (${$t('label.external')})` }}</span></a>
-        <span :title="displayCommentDate" class="dateTime caption font-italic d-block">{{ relativeTime }}</span>
+        <span :title="displayCommentDate(comment.comment.createdTime.time)" class="dateTime caption font-italic d-block">{{ relativeTime }}</span>
       </div>
     </div>
     <div class="commentBody ms-10 mt-1">


### PR DESCRIPTION
Problem: title attribute uses the reference of the function `displayCommentDate` instead of calling it.
Fix: Pass the correct parameter to the function.
(cherry picked from commit 5b55fa816e51bba8f2cf202b2c0291d91b5c0ff1)