### PR TITLE
43553: Fix due date before start date issue in Tasks 

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
@@ -78,6 +78,7 @@
                 value="left"
                 class="my-0"
                 small
+                :disabled="startDate > checkDate()"                
                 @click="addBtnDate()">
                 {{ $t('label.today') }}
               </v-btn>
@@ -86,6 +87,7 @@
                 value="center"
                 class="my-0"
                 small
+                :disabled="startDate > checkDate(1)"                
                 @click="addBtnDate(1)">
                 {{ $t('label.tomorrow') }}
               </v-btn>
@@ -94,6 +96,7 @@
                 value="right"
                 class="my-0"
                 small
+                :disabled="startDate > checkDate(7)"                
                 @click="addBtnDate(7)">
                 {{ $t('label.nextweek') }}
               </v-btn>
@@ -189,6 +192,14 @@ export default {
     });
   },
   methods: {
+    checkDate(days) {
+      if (!days) {
+        days=0;
+      }
+      const date = new Date();
+      date.setDate(date.getDate() + days);
+      return date;
+    },  
     reset() {
       if (this.actualTask.id!=null) {
         this.startDate = null;


### PR DESCRIPTION
Fix the issue of setting a due date before a start date through labels by disabling today/tomorrow/next week buttons if is the selected start date is greater then them.

(cherry picked from commit 4666f87803f8e73e9a6b843eeb9ff177930446c7)