### PR TITLE
Task-52342 : Tasks status not updated on the board when updating stat…

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -424,7 +424,7 @@ export default {
           this.$taskDrawerApi.updateTask(this.task.id, this.task).then( () => {
             this.oldTask.priority = this.task.priority;
             this.$root.$emit('task-updated', this.task);
-            this.$root.$emit('task-priority-updated',value);
+            this.$root.$emit('task-priority-updated',this.task);
             this.$root.$emit('show-alert', {
               type: 'success',
               message: this.$t('alert.success.task.priority')
@@ -447,6 +447,7 @@ export default {
           this.task.status = value;
           this.$taskDrawerApi.updateTask(this.task.id, this.task).then( () => {
             this.oldTask.status = this.task.status;
+            this.$root.$emit('task-status-updated',this.task);
             this.$root.$emit('show-alert', {
               type: 'success',
               message: this.$t('alert.success.task.status')
@@ -468,6 +469,7 @@ export default {
           this.$taskDrawerApi.updateTask(this.task.id, this.task).then( () => {
             this.oldTask.startDate = this.task.startDate;
             this.$root.$emit('task-updated', this.task);
+            this.$root.$emit('task-start-date-updated', this.task);
             this.$root.$emit('show-alert', {
               type: 'success',
               message: this.$t('alert.success.task.startDate')
@@ -491,6 +493,7 @@ export default {
           this.$taskDrawerApi.updateTask(this.task.id, this.task).then(() => {
             this.oldTask.dueDate = this.task.dueDate;
             this.$root.$emit('task-updated', this.task);
+            this.$root.$emit('task-due-date-updated', this.task);
             this.$root.$emit('show-alert', {
               type: 'success',
               message: this.$t('alert.success.task.duetDate')

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -296,24 +296,16 @@ export default {
       this.updateModifiedTask(task);
     });
 
-    this.$root.$on('task-priority-updated', value => {
-      if (this.tasksFilter.orderBy === 'priority') {
-        this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
-          if (Array.isArray(data.tasks[0])) {
-            const tasksArrayIndex = this.tasksList.findIndex(tasksArray => tasksArray.findIndex(t => t.id === value.taskId) > -1);
-            this.$set(this.tasksList, tasksArrayIndex, data.tasks[tasksArrayIndex]);
-          } else {
-            const taskOldIndex = this.tasksList.findIndex(t => t.id === value.taskId);
-            const taskNewIndex = data.tasks.findIndex(task => task.id === value.taskId);
-
-            this.tasksList.splice(taskOldIndex, 1);
-            this.tasksList.splice(taskNewIndex, 0, data.tasks[taskNewIndex]);
-          }
-        });
-      }
+    this.$root.$on('task-priority-updated', task => {
+      this.updateModifiedTask(task);
     });
-
+    this.$root.$on('task-start-date-updated', task => {
+      this.updateModifiedTask(task);
+    });
     this.$root.$on('task-due-date-updated', task => {
+      this.updateModifiedTask(task);
+    });
+    this.$root.$on('task-status-updated', task => {
       this.updateModifiedTask(task);
     });
     


### PR DESCRIPTION
…us just after assignment (#730)

* Task-52342 : Tasks status not updated on the board when updating status just after assignment

ISSUES : Tasks status ,priority start date and due date not updated on the tasks board just after assignment
FIX : to fix status problem i add event 'update-task-status'  on method 'updateTaskStatus' in TaskDrawer.vue then i  receive the event in TaskViewDashboard.vue ,
	to fix priority problem i just modified in   TaskViewDashboard.vue  when a call the event task-priority-updated ,
	to fix start date problem i add event 'task-start-date-updated'  on method 'updateTaskStartDate' in TaskDrawer.vue then i  receive the event in TaskViewDashboard.vue ,
	finally  to fix due date problem i just add event 'task-due-date-updated'  on method 'updateTaskStartDate' in TaskDrawer.vue