### PR TITLE
TASK-51342 : Edit task project after renaming a space leads to the loss of the project.

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
@@ -149,7 +149,7 @@ export default {
       }
     },
     reset() {
-      if (this.manager && !this.manager.length>0) { // In case of edit existing event
+      if (this.manager && this.manager.length>0) { 
         // Add current user as default attendee
         if (eXo.env.portal.spaceName) {
           this.manager = [{


### PR DESCRIPTION
ISSUES : Edit task project after renaming a space leads to the loss of the project.
FIX : the problem that the manager and participator variables did not take the right values ​​and which was solved by correcting the condition in order to take the right values.