### PR TITLE
TASK-52819 : can't close a task in the task drawer

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -394,7 +394,7 @@ export default {
     updateCompleted() {
       const task = {
         id: this.task.id,
-        showCompletedTasks: !this.task.completed,
+        isCompleted: !this.task.completed,
       };
       if (task.id) {
         return this.$tasksService.updateCompleted(task).then(updatedTask => {
@@ -404,9 +404,10 @@ export default {
             this.$root.$emit('show-alert', {type: 'success',message: this.$t('alert.success.task.unCompleted')});
           }
           this.$root.$emit('update-task-completed', updatedTask);
-        }).then( () => {
-          this.$root.$emit('update-completed-task',this.task.completed,this.task.id);
-        }).then(() => this.task.completed = task.showCompletedTasks)
+        }).then(() => this.task.completed = task.isCompleted)
+          .then( () => {
+            this.$root.$emit('update-completed-task',this.task.completed,this.task.id);
+          })
           .catch(e => {
             console.error('Error updating project', e);
             this.$root.$emit('show-alert', {


### PR DESCRIPTION
link : Task-52819

ISSUE : when trying to close a task from the task drawer, an alert message appears "task unmarked as completed successfully" but nothing changed.

FIX : use the right task object fields name "isCompleted" the same as used in the rest service + change the task's "completed" field to update the tasks board in realtime.