### PR TITLE
52923: Could not create a task

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/QuickAddCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/QuickAddCard.vue
@@ -13,8 +13,7 @@
       rows="1"
       row-height="13"
       required 
-      @keyup="checkImput($event)"
-      @blur="closeForm" />
+      @keyup="checkImput($event)"/>
     <div class="d-md-none">
       <v-spacer />
       <v-btn


### PR DESCRIPTION
ISSUE: The form to add an event is composed of an input text  field and two buttons, the input field has a blur event which closes the form when it's triggered. This event is also triggered when clicking on the save button to add the task.
FIX: Removed the blur event from the input field. To close the form the user has to click on the cancel button.