### PR TITLE
TASK-51872: Cannot remove start date of a task

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -493,7 +493,8 @@ export default {
             message: this.$t('alert.success.task.startDate')
           });
           this.$root.$emit('task-start-date-updated', this.task);
-        }).catch(() => {
+        }).catch(e => {
+          console.error('Error has occurred while removing the start date ' , e);
           this.$root.$emit('show-alert', {
             type: 'error',
             message: this.$t('alert.error')


### PR DESCRIPTION
issue: start date can't be removed when clicking on 'none' label from the datepicker
fix: add else-if statement to handle user's input on the datepicker when the value of entered label = 'none'