### PR TITLE
TASK-51342: Edit task project after renaming a space leads to the loss of the project.

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
@@ -265,8 +265,8 @@ export default {
             this.manager.forEach(manager_el => {
               if (manager_el.providerId ==='space') {
                 projects.spaceName = eXo.env.portal.spaceName;
-                projects.manager.push(`manager:/spaces/${manager_el.remoteId}`);
-                projects.participator.push(`member:/spaces/${manager_el.remoteId}`);
+                projects.manager.push(`manager:/spaces/${eXo.env.portal.spaceGroup}`);
+                projects.participator.push(`member:/spaces/${eXo.env.portal.spaceGroup}`);
               } else {
                 projects.manager.push(manager_el.remoteId);
               }

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeManager.vue
@@ -149,7 +149,7 @@ export default {
       }
     },
     reset() {
-      if (this.manager && this.manager.length>0) { 
+      if (this.manager && !this.manager.length>0) { 
         // Add current user as default attendee
         if (eXo.env.portal.spaceName) {
           this.manager = [{


### PR DESCRIPTION
ISSUES : Edit task project after renaming a space leads to the loss of the project.
FIX : the problem that the manager and participator variables did not take the right values ​​and which was solved by passing the value of the spaceGroup to manager and participator.