### PR TITLE
TASK-53005: In Tasks application, updating name project results loss of project.

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -328,7 +328,7 @@ public class ProjectRestService implements ResourceContainer {
               manager.put("providerId", "space");
               JSONObject profile = new JSONObject();
               profile.put("fullName", space.getDisplayName());
-              profile.put("originalName", space.getPrettyName());
+              profile.put("originalName", space.getGroupId());
               profile.put("avatarUrl", "/portal/rest/v1/social/spaces/" + space.getPrettyName() + "/avatar");
               manager.put("profile", profile);
               managersDetail.put(manager);

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/AddProjectDrawer.vue
@@ -265,8 +265,8 @@ export default {
             this.manager.forEach(manager_el => {
               if (manager_el.providerId ==='space') {
                 projects.spaceName = eXo.env.portal.spaceName;
-                projects.manager.push(`manager:/spaces/${eXo.env.portal.spaceGroup}`);
-                projects.participator.push(`member:/spaces/${eXo.env.portal.spaceGroup}`);
+                projects.manager.push(`manager:${manager_el.profile.originalName}`);
+                projects.participator.push(`member:${manager_el.profile.originalName}`);
               } else {
                 projects.manager.push(manager_el.remoteId);
               }


### PR DESCRIPTION
ISSUES : In Tasks application, when updating the project name, the updates are not immediately made and the display of the project is lost after refreshing.
FIX : the problem is that the manager and participator variables get the wrong value, so it is fixed by allow manager and participator variables to get the value of profile.originalName which contains the value of GroupId of space.